### PR TITLE
Fix results query generation

### DIFF
--- a/lib/stretchy/filters/not_filter.rb
+++ b/lib/stretchy/filters/not_filter.rb
@@ -4,22 +4,25 @@ module Stretchy
   module Filters
     class NotFilter < Base
 
-      contract :filter, type: Base
+      attr_reader :filters
 
-      def initialize(filters)
-        filters = Array(filters)
+      contract :filters, { type: Base, array: true, required: true }
 
-        if filters.count == 1
-          @filter = filters.first
-        else
-          @filter = AndFilter.new(filters)
-        end
-
+      def initialize(*filters)
+        @filters = Array(filters).flatten
         validate!
       end
 
+      def filter
+        if @filters.count > 1
+          AndFilter.new(@filters)
+        else
+          @filters.first
+        end
+      end
+
       def to_search
-        { not: @filter.to_search }
+        { not: filter.to_search }
       end
     end
   end

--- a/lib/stretchy/results/base.rb
+++ b/lib/stretchy/results/base.rb
@@ -2,14 +2,31 @@ module Stretchy
   module Results
     class Base
 
-      def initialize(request_json, options = {})
-        @request  = request_json
-        @index    = options[:index]
-        @type     = options[:type]
+      extend Forwardable
+
+      attr_reader :clause, :index_name
+
+      delegate [:type] => :clause
+
+      def initialize(clause)
+        @clause     = clause
+        @index_name = clause.index_name || Stretchy.index_name
+      end
+
+      def limit
+        clause.get_limit
+      end
+
+      def offset
+        clause.get_offset
+      end
+
+      def request
+        @request ||= {query: clause.to_search}
       end
 
       def response
-        @response ||= Stretchy.search(type: @type, body: request_json)
+        @response ||= Stretchy.search(type: type, body: request, from: offset, size: limit)
       end
 
       def ids
@@ -43,5 +60,3 @@ module Stretchy
     end
   end
 end
-
-require 'stretchy/results/null_results'

--- a/lib/stretchy/results/null_results.rb
+++ b/lib/stretchy/results/null_results.rb
@@ -6,6 +6,24 @@ module Stretchy
       # use this class when you don't want to actually run
       # a search, or catch an exception or something
 
+      def initialize(clause = nil)
+        @clause       = clause
+        @index_name   = clause.index_name if clause.is_a?(Stretchy::Clauses::Base)
+        @index_name ||= Stretchy.index_name
+      end
+
+      def request
+        {}
+      end
+
+      def limit
+        0
+      end
+
+      def offset
+        0
+      end
+
       def response
         @response ||= {
           'took'      => 0,

--- a/lib/stretchy/utils/client_actions.rb
+++ b/lib/stretchy/utils/client_actions.rb
@@ -21,20 +21,28 @@ module Stretchy
         Stretchy::Clauses::Base.new(*args, &block)
       end
 
-      def search(type:, body:, fields: nil)
-        options = { index: index_name, type: type, body: body }
-        options[:fields] = fields if fields.is_a?(Array)
+      def search(options = {})
+        params = {}
+        params[:index]  = options[:index] || index_name
+        params[:type]   = options[:type]
+        params[:fields] = Array(options[:fields]) if options[:fields]
+        params[:body]   = options[:body]
 
-        client.search(options)
+        client.search(params)
       end
 
-      def index(type:, body:, id: nil)
-        id ||= body['id'] || body['_id'] || body[:id] || body[:_id]
-        client.index(index: index_name, type: type, id: id, body: body)
+      def index(options = {})
+        index = options[:index] || index_name
+        type  = options[:type]
+        body  = options[:body]
+        id    = options[:id] || options['id'] || body['id'] || body['_id'] || body[:id] || body[:_id]
+        client.index(index: index, type: type, id: id, body: body)
       end
 
-      def bulk(type:, documents:)
-        requests = documents.flat_map do |document|
+      def bulk(options = {})
+        type      = options[:type]
+        documents = options[:documents]
+        requests  = documents.flat_map do |document|
           id = document['id'] || document['_id'] || document[:id] || document[:_id]
           [
             { index: { '_index' => index_name, '_type' => type, '_id' => id } },

--- a/lib/stretchy/utils/contract.rb
+++ b/lib/stretchy/utils/contract.rb
@@ -17,6 +17,7 @@ module Stretchy
           
           if options[:array]
             self.class.assert_type(name, value, type: Array)
+            self.class.assert_required(name, value, {}) if options[:required]
           end
 
           ASSERTIONS.each do |assertion|
@@ -60,7 +61,7 @@ module Stretchy
         end
 
         def assert_required(name, value, options)
-          msg = "Expected to have param #{name}, but got nil"
+          msg = "Expected to have param #{name}, but got an #{value.inspect}"
           fail_assertion(msg) if is_empty?(value)
         end
 

--- a/spec/stretchy/filters/not_filter_spec.rb
+++ b/spec/stretchy/filters/not_filter_spec.rb
@@ -16,6 +16,10 @@ describe Stretchy::Filters::NotFilter do
     subject.new(*args).to_search[:not]
   end
 
+  it 'builds an And filter' do
+    expect(subject.new(terms_filter, range_filter).filter).to be_a(Stretchy::Filters::AndFilter)
+  end
+
   it 'accepts a filter param' do
     result = get_result(terms_filter)
     expect(result).to eq(terms_filter.to_search)
@@ -27,7 +31,7 @@ describe Stretchy::Filters::NotFilter do
     expect(result[:and].last).to eq(range_filter.to_search)
   end
 
-  xit 'accepts filter arguments' do
+  it 'accepts filter arguments' do
     result = get_result(terms_filter, range_filter)
     expect(result[:and].first).to eq(terms_filter.to_search)
     expect(result[:and].last).to eq(range_filter.to_search)

--- a/spec/stretchy/results/base_spec.rb
+++ b/spec/stretchy/results/base_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Stretchy::Results::Base do
+
+  let(:request) { Stretchy.query(type: FIXTURE_TYPE).match(location: "Japan") }
+
+  subject { described_class.new(request) }
+
+  it 'accesses limit' do
+    expect(subject.limit).to eq(request.get_limit)
+  end
+
+  it 'accesses offset' do
+    expect(subject.offset).to eq(request.get_offset)
+  end
+
+  it 'generates request body' do
+    expect(subject.request).to be_a(Hash)
+  end
+
+  it 'generates response json' do
+    expect(subject.response).to be_a(Hash)
+  end
+
+  it 'retrieves ids and converts to integers' do
+    expect(subject.ids).to be_a(Array)
+    expect(subject.ids.count).to be > 1
+    expect(subject.ids.all?{|id| id.is_a?(Numeric)}).to eq(true)
+  end
+
+  it 'returns hits' do
+    expect(subject.hits.count).to be > 1
+    ['_index', '_type', '_id', '_score'].each do |field|
+      expect(subject.hits.first[field]).to_not be_nil
+    end
+  end
+
+  it 'returns how long the query took' do
+    expect(subject.took).to be > 0
+  end
+
+  it 'returns number of shards' do
+    expect(subject.shards).to be_a(Hash)
+  end
+
+  it 'returns total results' do
+    expect(subject.total).to eq(subject.hits.count)
+  end
+
+  it 'returns maximum query score' do
+    expect(subject.max_score).to be > 0
+  end
+
+end

--- a/spec/stretchy/results/null_results_spec.rb
+++ b/spec/stretchy/results/null_results_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Stretchy::Results::NullResults do
+
+  let(:request) { Stretchy.query(type: FIXTURE_TYPE).match(location: "Japan") }
+
+  it 'ignores optional clause param' do
+    expect(described_class.new.hits.count).to eq(0)
+  end
+
+  it 'returns limit' do
+    expect(subject.limit).to eq(0)
+  end
+
+  it 'returns offset' do
+    expect(subject.offset).to eq(0)
+  end
+
+  it 'generates request body' do
+    expect(subject.request).to eq({})
+  end
+
+  it 'generates response json' do
+    expect(subject.response).to be_a(Hash)
+  end
+
+  it 'retrieves ids and converts to integers' do
+    expect(subject.ids).to be_empty
+  end
+
+  it 'returns hits' do
+    expect(subject.hits.count).to eq(0)
+  end
+
+  it 'returns how long the query took' do
+    expect(subject.took).to eq(0)
+  end
+
+  it 'returns number of shards' do
+    expect(subject.shards).to eq({})
+  end
+
+  it 'returns total results' do
+    expect(subject.total).to eq(0)
+  end
+
+  it 'returns maximum query score' do
+    expect(subject.max_score).to eq(0)
+  end
+
+end

--- a/spec/stretchy/utils/contract_spec.rb
+++ b/spec/stretchy/utils/contract_spec.rb
@@ -18,6 +18,7 @@ describe Stretchy::Utils::Contract do
     contract :lng,          type: :lng
     contract :field,        type: :field
     contract :req,          required: true
+    contract :arr_req,      type: Numeric, array: true, required: true
 
     def initialize(options = {})
       options.each do |key, val|
@@ -48,7 +49,8 @@ describe Stretchy::Utils::Contract do
       lat:          45.01,
       lng:          133.21,
       field:        :json_field,
-      req:          true
+      req:          true,
+      arr_req:      [1, 2]
     }
   end
 
@@ -115,6 +117,12 @@ describe Stretchy::Utils::Contract do
       check_raises_error req: []
       check_raises_error req: {}
       check_raises_error req: ''
+    end
+
+    it 'empty array with require' do
+      check_raises_error arr_req: ['wat']
+      check_raises_error arr_req: []
+      check_raises_error arr_req: nil
     end
   end
 


### PR DESCRIPTION
Also remove more key / val arguments, require non-empty arrays, and accept splat args for NotFilter