### PR TITLE
Fix gotchas and bugs 

### DIFF
--- a/lib/stretchy/boosts/field_decay_boost.rb
+++ b/lib/stretchy/boosts/field_decay_boost.rb
@@ -27,10 +27,12 @@ module Stretchy
       end
 
       def to_search
-        json = {
-          origin: @origin,
-          scale: @scale,
-        }
+        json = {scale: @scale}
+        if @origin.is_a?(Stretchy::Types::Base)
+          json[:origin] = @origin.to_search
+        else
+          json[:origin] = @origin
+        end
         json[:offset] = @offset  if @offset
         json[:decay]  = @decay   if @decay
 

--- a/lib/stretchy/builders/where_builder.rb
+++ b/lib/stretchy/builders/where_builder.rb
@@ -167,7 +167,9 @@ module Stretchy
         near_fields = Hash(options[:near_fields])
         exists      = Array(options[:exists])
         
-        filters << Stretchy::Filters::TermsFilter.new(terms) if terms.any?
+        terms.each do |field, values|
+          filters << Stretchy::Filters::TermsFilter.new(field, values)
+        end
         
         filters += exists.map do |field|
           Stretchy::Filters::ExistsFilter.new(field)

--- a/lib/stretchy/clauses/base.rb
+++ b/lib/stretchy/clauses/base.rb
@@ -10,7 +10,7 @@ module Stretchy
       attr_accessor :match_builder, :where_builder, :boost_builder, 
                     :aggregate_builder, :inverse, :type, :index_name
 
-      delegate [:response, :results, :ids, :hits, :took, :shards, :total, :max_score] => :query_results
+      delegate [:request, :response, :results, :ids, :hits, :took, :shards, :total, :max_score] => :query_results
       delegate [:range, :geo] => :where
 
       def initialize(base_or_opts = nil, options = {})
@@ -106,7 +106,7 @@ module Stretchy
       end
 
       def query_results
-        @query_results ||= Stretchy::Results::Base.new(to_search.merge(from: @limit, size: @offset), type: @type)
+        @query_results ||= Stretchy::Results::Base.new(self)
       end
 
     end

--- a/lib/stretchy/clauses/base.rb
+++ b/lib/stretchy/clauses/base.rb
@@ -10,7 +10,8 @@ module Stretchy
       attr_accessor :match_builder, :where_builder, :boost_builder, 
                     :aggregate_builder, :inverse, :type, :index_name
 
-      delegate [:request, :response, :results, :ids, :hits, :took, :shards, :total, :max_score] => :query_results
+      delegate [:request, :response, :results, :ids, :hits, 
+                :took, :shards, :total, :max_score] => :query_results
       delegate [:range, :geo] => :where
 
       def initialize(base_or_opts = nil, options = {})
@@ -60,10 +61,12 @@ module Stretchy
       def match(options = {})
         MatchClause.new(self, options)
       end
+      alias :fulltext :match
 
       def where(options = {})
         WhereClause.new(self, options)
       end
+      alias :filter :where
 
       def boost(options = {})
         BoostClause.new(self, options)

--- a/lib/stretchy/clauses/boost_clause.rb
+++ b/lib/stretchy/clauses/boost_clause.rb
@@ -16,10 +16,12 @@ module Stretchy
       def match(options = {})
         BoostMatchClause.new(self, options)
       end
+      alias :fulltext :match
 
       def where(options = {})
         BoostWhereClause.new(self, options)
       end
+      alias :filter :where
 
       def near(options = {})
         if options[:lat] || options[:latitude]  ||

--- a/lib/stretchy/clauses/boost_match_clause.rb
+++ b/lib/stretchy/clauses/boost_match_clause.rb
@@ -4,6 +4,8 @@ module Stretchy
   module Clauses
     class BoostMatchClause < BoostClause
 
+      delegate [:range, :geo] => :where
+
       def initialize(base, opts_or_string = {}, options = {})
         super(base)
         if opts_or_string.is_a?(Hash)
@@ -17,6 +19,14 @@ module Stretchy
 
       def not(opts_or_string = {}, options = {})
         self.class.new(self, opts_or_string, options.merge(inverse: !inverse?))
+      end
+
+      def where(*args)
+        WhereClause.new(self, *args)
+      end
+
+      def match(*args)
+        MatchClause.new(self, *args)
       end
 
       private

--- a/lib/stretchy/clauses/boost_where_clause.rb
+++ b/lib/stretchy/clauses/boost_where_clause.rb
@@ -10,14 +10,22 @@ module Stretchy
         self
       end
 
+      def where(*args)
+        WhereClause.new(self, *args)
+      end
+
+      def match(*args)
+        MatchClause.new(self, *args)
+      end
+
       def range(*args)
         where_function(:range, *args)
-        self
+        Base.new(self)
       end
 
       def geo(*args)
         where_function(:geo, *args)
-        self
+        Base.new(self)
       end
 
       private

--- a/lib/stretchy/clauses/where_clause.rb
+++ b/lib/stretchy/clauses/where_clause.rb
@@ -112,6 +112,7 @@ module Stretchy
             get_storage(:exists, true) << field
           when String, Symbol
             get_storage(:matches)[field] += Array(param)
+            get_storage(:matchops)[field] = 'or'
           when Range
             get_storage(:ranges)[field] = Stretchy::Types::Range.new(param)
           else

--- a/lib/stretchy/filters/terms_filter.rb
+++ b/lib/stretchy/filters/terms_filter.rb
@@ -5,27 +5,19 @@ module Stretchy
     class TermsFilter < Base
 
       contract field: {type: :field, required: true},
-              values: {type: Array,  required: true}
+               terms: {type: [Numeric, Time, String, Symbol], array: true,  required: true}
 
-      def initialize(field_or_opts = {}, terms = [])
-        if field_or_opts.is_a?(Hash)
-          @terms = field_or_opts
-        else
-          @terms = { field_or_opts => Array(terms) }
-        end
-        validate_terms!
-      end
-
-      def validate_terms!
-        exc = Stretchy::Errors::ContractError.new("Terms cannot be blank")
-        raise exc if @terms.none? || @terms.any? do |field, terms|
-          terms.none?
-        end
+      def initialize(field, terms)
+        @field = field
+        @terms = Array(terms)
+        validate!
       end
 
       def to_search
         {
-          terms: @terms
+          terms: {
+            @field => @terms
+          }
         }
       end
     end

--- a/spec/stretchy/boosts/field_decay_boost_spec.rb
+++ b/spec/stretchy/boosts/field_decay_boost_spec.rb
@@ -60,6 +60,23 @@ describe Stretchy::Boosts::FieldDecayBoost do
       result = get_result(params.merge(decay: 0.5))
       expect(result[:gauss][params[:field]][:decay]).to eq(0.5)
     end
+
+    context 'geo_point param' do
+      let(:point) { Stretchy::Types::GeoPoint.new(lat: 27.7, lon: 38.3) }
+      let(:params) do
+        {
+          field: :coords,
+          origin: point,
+          scale: '27km'
+        }
+      end
+
+      specify 'lat and lon' do
+        result = get_result(params)
+        expect(result[:gauss][params[:field]][:origin][:lat]).to eq(point.lat)
+        expect(result[:gauss][params[:field]][:origin][:lon]).to eq(point.lon)
+      end
+    end
   end
 
 end

--- a/spec/stretchy/builders/match_builder_spec.rb
+++ b/spec/stretchy/builders/match_builder_spec.rb
@@ -39,17 +39,37 @@ describe Stretchy::Builders::MatchBuilder do
       expect(should_not[:match][:fieldname]).to eq(query: 'one', operator: 'and')
     end
 
-    it 'works with all options' do
-      subject.matches[:matchfield]                = ['match', 'this']
-      subject.antimatches[:anti_field]            = ['do not match this']
-      subject.shouldmatches[:should_field]        = ['should match']
-      subject.shouldnotmatches[:should_not_field] = ['should', 'not', :match]
+    context 'with all options' do
 
-      expect(result[:must].first[:match][:matchfield]).to eq(query: 'match this', operator: 'and')
-      expect(result[:must_not].first[:match][:anti_field]).to eq(query: 'do not match this', operator: 'and')
-      shoulds = result[:should].first[:bool]
-      expect(shoulds[:must].first[:match][:should_field]).to eq(query: 'should match', operator: 'and')
-      expect(shoulds[:must_not].first[:match][:should_not_field]).to eq(query: 'should not match', operator: 'and')
+      before do
+        subject.matches[:matchfield]                = ['match', 'this']
+        subject.antimatches[:anti_field]            = ['do not match this']
+        subject.shouldmatches[:should_field]        = ['should match']
+        subject.shouldnotmatches[:should_not_field] = ['should', 'not', :match]
+      end
+
+      it 'produces expected json' do
+        expect(result[:must].first[:match][:matchfield]).to eq(query: 'match this', operator: 'and')
+        expect(result[:must_not].first[:match][:anti_field]).to eq(query: 'do not match this', operator: 'and')
+        shoulds = result[:should].first[:bool]
+        expect(shoulds[:must].first[:match][:should_field]).to eq(query: 'should match', operator: 'and')
+        expect(shoulds[:must_not].first[:match][:should_not_field]).to eq(query: 'should not match', operator: 'and')
+      end
+
+      it 'uses matchops to determine operator' do
+        subject.matchops[:matchfield] = 'or'
+        subject.antimatchops[:anti_field] = 'or'
+        subject.shouldmatchops[:should_field] = 'or'
+        subject.shouldnotmatchops[:should_not_field] = 'or'
+
+        expect(result[:must].first[:match][:matchfield]).to eq(query: 'match this', operator: 'or')
+        expect(result[:must_not].first[:match][:anti_field]).to eq(query: 'do not match this', operator: 'or')
+        
+        shoulds = result[:should].first[:bool]
+        expect(shoulds[:must].first[:match][:should_field]).to eq(query: 'should match', operator: 'or')
+        expect(shoulds[:must_not].first[:match][:should_not_field]).to eq(query: 'should not match', operator: 'or')
+      end
+
     end
   end
 end

--- a/spec/stretchy/clauses/base_spec.rb
+++ b/spec/stretchy/clauses/base_spec.rb
@@ -52,4 +52,26 @@ describe Stretchy::Clauses::Base do
     expect(described_class.new.to_search).to eq(match_all: {})
   end
 
+  it 'is not inverse by default' do
+    expect(subject.inverse?).to eq(false)
+  end
+
+  it 'produces request json via to_search' do
+    expect(subject.to_search).to be_a(Hash)
+  end
+
+  it 'returns a results object' do
+    expect(subject.query_results).to be_a(Stretchy::Results::Base)
+    expect(subject.request).to be_a(Hash)
+    expect(subject.response).to be_a(Hash)
+    expect(subject.results.all?{|r| r.is_a?(Hash)}).to eq(true)
+    expect(subject.ids.all?{|id| id.is_a?(Numeric)}).to eq(true)
+    expect(subject.took).to be_a(Numeric)
+    expect(subject.shards).to be_a(Hash)
+    expect(subject.total).to be_a(Numeric)
+    expect(subject.max_score).to be_a(Numeric)
+
+
+  end
+
 end

--- a/spec/stretchy/clauses/boost_match_clause_spec.rb
+++ b/spec/stretchy/clauses/boost_match_clause_spec.rb
@@ -87,4 +87,32 @@ describe Stretchy::Clauses::BoostMatchClause do
       expect(subject.not.inverse?).to eq(true)
     end
   end
+
+  describe 'cannot chain' do
+    subject { described_class.new(base).match('matchstr') }
+
+    specify 'match' do
+      instance = subject.match('filtermatch')
+      expect(instance).to be_a(Stretchy::Clauses::MatchClause)
+      expect(instance.match_builder.matches['_all']).to include('filtermatch')
+    end
+
+    specify 'where' do
+      instance = subject.where(filter_field: 27)
+      expect(instance).to be_a(Stretchy::Clauses::WhereClause)
+      expect(instance.where_builder.terms[:filter_field]).to include(27)
+    end
+
+    specify 'range' do
+      instance = subject.range(:range_field, min: 33)
+      expect(instance).to be_a(Stretchy::Clauses::WhereClause)
+      expect(instance.where_builder.ranges[:range_field]).to be_a(Stretchy::Types::Range)
+    end
+
+    specify 'geo' do
+      instance = subject.geo(:geo_field, distance: '33km', lat: 22, lng: 47)
+      expect(instance).to be_a(Stretchy::Clauses::WhereClause)
+      expect(instance.where_builder.geos[:geo_field]).to include(distance: '33km')
+    end
+  end
 end

--- a/spec/stretchy/clauses/boost_where_clause_spec.rb
+++ b/spec/stretchy/clauses/boost_where_clause_spec.rb
@@ -45,4 +45,32 @@ describe Stretchy::Clauses::BoostWhereClause do
       expect(subject.not.inverse?).to eq(true)
     end
   end
+
+  describe 'cannot chain' do
+    subject { described_class.new(base) }
+
+    specify 'where' do
+      instance = subject.where(filter_field: 27)
+      expect(instance).to be_a(Stretchy::Clauses::WhereClause)
+      expect(instance.where_builder.terms[:filter_field]).to include(27)
+    end
+
+    specify 'match' do
+      instance = subject.match('string')
+      expect(instance).to be_a(Stretchy::Clauses::MatchClause)
+      expect(instance.match_builder.matches['_all']).to include('string')
+    end
+
+    specify 'range' do
+      instance = subject.range(:range_field, min: 88).range(:filter_range, max: 33)
+      expect(instance).to be_a(Stretchy::Clauses::WhereClause)
+      expect(instance.where_builder.ranges[:filter_range]).to be_a(Stretchy::Types::Range)
+    end
+
+    specify 'geo' do
+      instance = subject.geo(:geo_field, distance: '27km', lat: 88.3, lng: 22.1).geo(:filter_geo, distance: '35mi', lat: 22.9, lng: 82.1)
+      expect(instance).to be_a(Stretchy::Clauses::WhereClause)
+      expect(instance.where_builder.geos[:filter_geo]).to include(distance: '35mi')
+    end
+  end
 end

--- a/spec/stretchy/clauses/where_clause_spec.rb
+++ b/spec/stretchy/clauses/where_clause_spec.rb
@@ -18,12 +18,17 @@ describe Stretchy::Clauses::WhereClause do
         symbol_field: :my_symbol
       )
       expect(instance.match_builder.matches[:field_one]).to include('one')
+      expect(instance.match_builder.matchops[:field_one]).to eq('or')
       expect(instance.match_builder.matches[:symbol_field]).to include(:my_symbol)
+      expect(instance.match_builder.matchops[:symbol_field]).to eq('or')
+      
       expect(instance.where_builder.terms[:number_field]).to include(86)
       expect(instance.where_builder.antiexists).to include(:nil_field)
+      
       expect(instance.where_builder.ranges[:range_field]).to be_a(Stretchy::Types::Range)
       expect(instance.where_builder.ranges[:range_field].min).to eq(27)
       expect(instance.where_builder.ranges[:range_field].max).to eq(34)
+      
       [:shouldterms, :shouldnotterms, :shouldranges, 
        :shouldnotranges, :shouldgeos, :shouldnotgeos,
        :shouldexists, :shouldnotexists].each do |field|

--- a/spec/stretchy/filters/terms_filter_spec.rb
+++ b/spec/stretchy/filters/terms_filter_spec.rb
@@ -22,12 +22,6 @@ describe Stretchy::Filters::TermsFilter do
     expect(result[field].first).to eq(values.first)
   end
 
-  it 'takes a hash as param' do
-    result = get_result(field_one: ['one', 'two'], field_two: ['three', 'four'])
-    expect(result[:field_one]).to eq(['one', 'two'])
-    expect(result[:field_two]).to eq(['three', 'four'])
-  end
-
   it 'raises error for invalid types' do
     expect{subject.new(field: '', values: 'wat')}.to raise_error
   end

--- a/spec/stretchy_spec.rb
+++ b/spec/stretchy_spec.rb
@@ -89,7 +89,7 @@ describe Stretchy do
       
       result = clause.to_search
       # puts JSON.pretty_generate clause.to_search
-      expect{Stretchy.search(type: FIXTURE_TYPE, body: {query: result})}.to_not raise_error
+      expect(clause.results).to be_a(Array)
 
       filtered_query = result[:function_score][:query][:filtered]
       

--- a/spec/stretchy_spec.rb
+++ b/spec/stretchy_spec.rb
@@ -96,22 +96,22 @@ describe Stretchy do
       query = filtered_query[:query][:bool][:must]
       expect(query).to include(match: { '_all' => { query: 'all_match', operator: 'and' }})
       expect(query).to include(match: { match_field: { query: 'match_field_string', operator: 'and' }})
-      expect(query).to include(match: { must_string_field: { query: 'must_string', operator: 'and' }})
+      expect(query).to include(match: { must_string_field: { query: 'must_string', operator: 'or' }})
       expect(query).to include(match: { 
         must_terms: { 
           query: 'must_symbol_in_array must_string_in_array_terms', 
-          operator: 'and' 
+          operator: 'or' 
         }
       })
 
       not_query = result[:function_score][:query][:filtered][:query][:bool][:must_not]
       expect(not_query).to include(match: {'_all' => { query: 'all_not_match', operator: 'and'}})
       expect(not_query).to include(match: {not_match_field: { query: 'not_match_field_string', operator: 'and'}})
-      expect(not_query).to include(match: {must_not_string_field: { query: 'must_not_string', operator: 'and'}})
+      expect(not_query).to include(match: {must_not_string_field: { query: 'must_not_string', operator: 'or'}})
       expect(not_query).to include(match: {
         must_not_terms: { 
           query: 'must_not_string_in_array must_not_symbol_in_array', 
-          operator: 'and'
+          operator: 'or'
         }
       })
 
@@ -193,7 +193,7 @@ describe Stretchy do
                       match: {
                         boost_string_field: {
                           query: 'boost_string',
-                          operator: 'and'
+                          operator: 'or'
                         }
                       }
                     },
@@ -201,7 +201,7 @@ describe Stretchy do
                       match: {
                         boost_terms: {
                           query: 'boost_string_term boost_symbol_term',
-                          operator: 'and'
+                          operator: 'or'
                         }
                       }
                     }


### PR DESCRIPTION
`.where(field: ['string1', 'string2'])` should use `or` instead of `and` , added matches 

`.boost.where().where()` does not add a second "boost where" clause, but adds a "where" filter using the options from the second call. This prevents chaining weirdness.

Fixed term filter generation in `where_builder` , since the terms filter cannot take multiple params.

