### PR TITLE
Add .explain to query chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,14 @@ Stretchy is still in early development, so it does not yet support the full feat
 Stretchy.configure do |c|
   c.index_name = 'my_index'                       # REQUIRED
   c.client     = $my_client                       # ignore below, use a custom client
-  c.logger     = Logger.new(STDOUT)               # passed to elasticsearch-api gem
   c.url        = 'https://user:pw@my.elastic.url' # default is ENV['ELASTICSEARCH_URL']
   c.adapter    = :patron                          # default is :excon
+
+  c.logger     = Logger.new(STDOUT)               # passed to elasticsearch-api gem
+                                                  # Stretchy will also log, with the params
+                                                  # specified below
+  c.log_level  = :debug                           # default is :silence
+  c.log_color  = :green                           # default is :blue 
 end
 ```
 

--- a/lib/stretchy/clauses/base.rb
+++ b/lib/stretchy/clauses/base.rb
@@ -51,6 +51,7 @@ module Stretchy
           @inverse            = options[:inverse] || base.inverse
           @limit              = base.get_limit
           @offset             = base.get_offset
+          @explain            = base.get_explain
         else
           options = Hash(base_or_opts).merge(options)
           @index_name         = options[:index] || Stretchy.index_name
@@ -107,6 +108,22 @@ module Stretchy
       # @return [Integer] Offset for query
       def get_offset
         @offset
+      end
+
+      # 
+      # Tells the search to explain the scoring
+      # mechanism for each document.
+      # 
+      # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-explain.html Elastic Docs - Request Body Search (explain)
+      # 
+      # @return [self] Allows continuing the query chain
+      def explain
+        @explain = true
+        self
+      end
+
+      def get_explain
+        !!@explain
       end
 
       # 

--- a/lib/stretchy/results/base.rb
+++ b/lib/stretchy/results/base.rb
@@ -26,7 +26,14 @@ module Stretchy
       end
 
       def response
-        @response ||= Stretchy.search(type: type, body: request, from: offset, size: limit)
+        params = {
+          type: type, 
+          body: request,
+          from: offset,
+          size: limit
+        }
+        params[:explain] = true if clause.get_explain
+        @response ||= Stretchy.search(params)
       end
 
       def ids
@@ -40,6 +47,18 @@ module Stretchy
         end
       end
       alias :results :hits
+
+      def scores
+        @scores ||= Hash[response['hits']['hits'].map do |hit|
+          [hit['_id'], hit['_score']]
+        end]
+      end
+
+      def explanations
+        @scores ||= Hash[response['hits']['hits'].map do |hit|
+          [hit['_id'], hit['_explanation']]
+        end]
+      end
 
       def took
         @took ||= response['took']

--- a/lib/stretchy/utils.rb
+++ b/lib/stretchy/utils.rb
@@ -1,3 +1,5 @@
+require 'stretchy/utils/contract'
+require 'stretchy/utils/colorize'
+require 'stretchy/utils/logger'
 require 'stretchy/utils/configuration'
 require 'stretchy/utils/client_actions'
-require 'stretchy/utils/contract'

--- a/lib/stretchy/utils/colorize.rb
+++ b/lib/stretchy/utils/colorize.rb
@@ -1,0 +1,71 @@
+module Stretchy
+  module Utils
+    class Colorize
+      COLORS = {
+        "default" => "38",
+        "black" => "30",
+        "red" => "31",
+        "green" => "32",
+        "brown" => "33",
+        "blue" => "34",
+        "purple" => "35",
+        "cyan" => "36",
+        "gray" => "37",
+        "dark gray" => "1;30",
+        "light red" => "1;31",
+        "light green" => "1;32",
+        "yellow" => "1;33",
+        "light blue" => "1;34",
+        "light purple" => "1;35",
+        "light cyan" => "1;36",
+        "white" => "1;37"
+      }.freeze
+
+      BG_COLORS = {
+        "default" => "0",
+        "black" => "40",
+        "red" => "41",
+        "green" => "42",
+        "brown" => "43",
+        "blue" => "44",
+        "purple" => "45",
+        "cyan" => "46",
+        "gray" => "47",
+        "dark gray" => "100",
+        "light red" => "101",
+        "light green" => "102",
+        "yellow" => "103",
+        "light blue" => "104",
+        "light purple" => "105",
+        "light cyan" => "106",
+        "white" => "107"
+      }.freeze
+
+      def colorize(string, color = "default", bg = "default")
+        color_code = COLORS[color]
+        bg_code = BG_COLORS[bg]
+        return "\033[#{bg_code};#{color_code}m#{string}\033[0m"
+      end
+
+      module ClassMethods
+        def colors
+          Colorize::COLORS
+        end
+
+        def bgs
+          Colorize::BG_COLORS
+        end
+
+        Colorize::COLORS.keys.each do |color|
+          define_method color do |string|
+            color_code = colors[color]
+            bg_code = bgs["default"]
+            string.split("\n").map{|s| "\033[#{bg_code};#{color_code}m#{s}\033[0m" }.join("\n")
+          end
+        end
+      end
+
+      extend ClassMethods
+    end
+  end
+end

--- a/lib/stretchy/utils/configuration.rb
+++ b/lib/stretchy/utils/configuration.rb
@@ -2,7 +2,7 @@ module Stretchy
   module Utils
     module Configuration
       
-      attr_accessor :index_name, :logger, :url, :adapter, :client
+      attr_accessor :index_name, :logger, :log_level, :log_color, :url, :adapter, :client
 
       def self.extended(base)
         base.set_default_configuration
@@ -16,6 +16,7 @@ module Stretchy
         self.index_name = 'myapp'
         self.adapter =    :excon
         self.url =        ENV['ELASTICSEARCH_URL']
+        self.log_level =  :silence
       end
 
       def client_options
@@ -34,6 +35,14 @@ module Stretchy
 
       def client(options = {})
         @client || connect(options)
+      end
+
+      def log_handler
+        @log_handler ||= Stretchy::Utils::Logger.new(logger, log_level, log_color)
+      end
+
+      def log(*args)
+        args.each {|arg| log_handler.log(arg) }
       end
     end
   end

--- a/lib/stretchy/utils/logger.rb
+++ b/lib/stretchy/utils/logger.rb
@@ -1,0 +1,59 @@
+require 'json'
+require 'stretchy/utils/colorize'
+
+module Stretchy
+  module Utils
+    class Logger
+
+      include Stretchy::Utils::Contract
+
+      LEVELS = [:silence, :debug, :info, :warn, :error, :fatal]
+
+      attr_accessor :base, :level, :color
+
+      contract base: { responds_to: LEVELS.last },
+              level: { in: LEVELS },
+              color: { in: Colorize::COLORS }
+
+      def self.log(msg_or_obj)
+        self.new.log(msg_or_obj)
+      end
+
+      def initialize(base = nil, level = nil, color = nil)
+        @base  = base       || ::Logger.new(STDOUT)
+        @level = level      || :silence
+        @color = color      || :blue
+
+        @color = @color.to_s if @color.is_a?(Symbol)
+        validate!
+      end
+
+      def log(msg_or_obj, _level = nil, _color = nil)
+        _level ||= level
+        _color ||= color
+        
+        return if _level == :silence
+        output = nil
+
+        case msg_or_obj
+        when String
+          output = Colorize.send(_color, msg_or_obj)
+        when Hash, Array
+          output = Colorize.send(_color, JSON.pretty_generate(msg_or_obj))
+        when Stretchy::Boosts::Base, Stretchy::Filters::Base, Stretchy::Queries::Base
+          output = Colorize.send(_color, JSON.pretty_generate(msg_or_obj.to_search))
+        else
+          output = Colorize.send(_color, msg_or_obj.inspect)
+        end
+
+        base.send(_level, output)
+      end
+
+      LEVELS.each do |_level|
+        define_method _level do |msg_or_obj, _color|
+          send(log, _level, msg_or_obj)
+        end
+      end
+    end
+  end
+end

--- a/spec/stretchy/results/base_spec.rb
+++ b/spec/stretchy/results/base_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Stretchy::Results::Base do
 
   let(:request) { Stretchy.query(type: FIXTURE_TYPE).match(location: "Japan") }
+  let(:found)   { fixture(:sakurai) }
 
   subject { described_class.new(request) }
 
@@ -32,6 +33,22 @@ describe Stretchy::Results::Base do
     expect(subject.hits.count).to be > 1
     ['_index', '_type', '_id', '_score'].each do |field|
       expect(subject.hits.first[field]).to_not be_nil
+    end
+  end
+
+  it 'returns scores' do
+    expect(subject.scores).to be_a(Hash)
+    expect(subject.scores.count).to be > 1
+    expect(subject.scores[found['id'].to_s]).to be_a(Numeric)
+  end
+
+  context 'with explanation' do
+    let(:request) { Stretchy.query(type: FIXTURE_TYPE).match(location: "Japan").explain }
+
+    it 'returns explanations' do
+      expect(subject.explanations).to be_a(Hash)
+      expect(subject.explanations.count).to be > 1
+      expect(subject.explanations[found['id'].to_s]).to be_a(Hash)
     end
   end
 

--- a/spec/stretchy/utils/colorize_spec.rb
+++ b/spec/stretchy/utils/colorize_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Stretchy::Utils::Colorize do
+
+  it 'colorizes via instance method' do
+    expect(subject.colorize("Red string", "red")).to match(/Red string/)
+  end
+
+  it 'colorizes via class method' do
+    expect(described_class.red("Red String")).to match(/Red String/)
+  end
+
+  it 'references colors' do
+    expect(described_class.colors).to be_a(Hash)
+  end
+
+  it 'references bg colors' do
+    expect(described_class.bgs).to be_a(Hash)
+  end
+
+end

--- a/spec/stretchy/utils/logger_spec.rb
+++ b/spec/stretchy/utils/logger_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Stretchy::Utils::Logger do
+
+  it 'can initialize with default attributes' do
+    expect(subject).to be_a(described_class)
+  end
+
+  it 'can initialize with params' do
+    expect(described_class.new(Logger.new(STDERR), :warn, 'red')).to be_a(described_class)
+  end
+
+  describe 'invalid params' do
+
+    specify 'not a real logger' do
+      expect{described_class.new('wat')}.to raise_error
+    end
+
+    specify 'not a real log level' do
+      expect{described_class.new(nil, :fubared)}.to raise_error
+    end
+
+    specify 'not a real color for output' do
+      expect{described_class.new(nil, :debug, :sky)}.to raise_error
+    end
+
+  end
+
+  context 'logging to /dev/null' do
+    let(:logger) { Logger.new('/dev/null') }
+    subject { described_class.new(logger, :debug) }
+
+    before do
+      Stretchy::Utils::Colorize.colors.keys.each do |color|
+        allow(Stretchy::Utils::Colorize).to receive(color) { |arg| arg }
+      end
+    end
+
+    it 'can log a message' do
+      expect(logger).to receive(:debug).with("A message")
+      subject.log("A message")
+    end
+
+    it 'logs hashes and arrays' do
+      expect(logger).to receive(:debug).with(JSON.pretty_generate({a: 'hash'}))
+      subject.log({a: 'hash'})
+    end
+
+    it 'logs arrays' do
+      expect(logger).to receive(:debug).with(JSON.pretty_generate([1, 'two']))
+      subject.log([1, 'two'])
+    end
+  end
+
+  it 'does not log if level is :silence' do
+    expect(subject.base).not_to receive(:debug)
+    subject.level = :silence
+    subject.log("A string")
+  end
+
+end

--- a/spec/stretchy_spec.rb
+++ b/spec/stretchy_spec.rb
@@ -18,6 +18,7 @@ describe Stretchy do
       index: Stretchy.index_name, 
       type: FIXTURE_TYPE, 
       body: {:query=>{:match_all=>{}}},
+      explain: true,
       size: 20,
       from: 1
     )
@@ -25,6 +26,7 @@ describe Stretchy do
     Stretchy.search(
       type: FIXTURE_TYPE,
       body: {query: Stretchy::Queries::MatchAllQuery.new.to_search},
+      explain: true,
       from: 1,
       size: 20
     )


### PR DESCRIPTION
Lost this method when redoing the single-layer chainable classes