### PR TITLE
Explicit where / match / should / not chaining

### DIFF
--- a/lib/stretchy/clauses/base.rb
+++ b/lib/stretchy/clauses/base.rb
@@ -48,7 +48,7 @@ module Stretchy
           @where_builder      = base.where_builder
           @boost_builder      = base.boost_builder
           @aggregate_builder  = base.aggregate_builder
-          @inverse            = options[:inverse] || base.inverse
+          @inverse            = options[:inverse]
           @limit              = base.get_limit
           @offset             = base.get_offset
           @explain            = base.get_explain
@@ -183,17 +183,21 @@ module Stretchy
 
       # 
       # Used for boosting the relevance score of
-      # search results. Options passed here correspond
-      # to `where`-style filters which boost a document
-      # if matched.
+      # search results. `match` and `where` clauses
+      # added after `boost` will be applied as
+      # boosting functions instead of filters
       # 
-      # @param options = {} [type] [description]
+      # @example Boost documents that match a filter
+      #   query.boost.where('post.user_id' => current_user.id)
+      # 
+      # @example Boost documents that match fulltext search
+      #   query.boost.match('user search terms')
       # 
       # @return [BoostClause] query in boost context
       # 
       # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html Elastic Docs - Function Score Query
-      def boost(options = {})
-        BoostClause.new(self, options)
+      def boost
+        BoostClause.new(self)
       end
 
       # 
@@ -213,9 +217,9 @@ module Stretchy
       #   is given (ie, doing a full-text search across the whole document)
       def not(opts_or_string = {}, opts = {})
         if opts_or_string.is_a?(Hash)
-          WhereClause.new(self, opts_or_string.merge(inverse: true))
+          WhereClause.new(self).not(opts_or_string)
         else
-          MatchClause.new(self, opts_or_string, opts.merge(inverse: true))
+          MatchClause.new(self).not(opts_or_string)
         end
       end
 
@@ -239,9 +243,9 @@ module Stretchy
       # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-filter.html Elastic Docs - Bool Filter
       def should(opts_or_string = {}, opts = {})
         if opts_or_string.is_a?(Hash)
-          WhereClause.new(self, opts_or_string.merge(should: true))
+          WhereClause.new(self).should(opts_or_string)
         else
-          MatchClause.new(self, opts_or_string, opts.merge(should: true))
+          MatchClause.new(self).should(opts_or_string)
         end
       end
 

--- a/lib/stretchy/clauses/boost_clause.rb
+++ b/lib/stretchy/clauses/boost_clause.rb
@@ -31,9 +31,8 @@ module Stretchy
       # @param options = {} [Hash] Options for the boost clause
       # @option options [true, false] :inverse (nil) If this boost should also be in the inverse state
       # 
-      def initialize(base, options = {})
+      def initialize(base)
         super(base)
-        @inverse = options.delete(:inverse)
       end
 
       # 
@@ -199,7 +198,8 @@ module Stretchy
       # 
       # @return [BoostClause] Boost clause in inverse context
       def not(options = {})
-        self.class.new(self, options.merge(inverse: !inverse?))
+        @inverse = true
+        self
       end
 
     end

--- a/lib/stretchy/clauses/boost_match_clause.rb
+++ b/lib/stretchy/clauses/boost_match_clause.rb
@@ -30,10 +30,8 @@ module Stretchy
       def initialize(base, opts_or_string = {}, options = {})
         super(base)
         if opts_or_string.is_a?(Hash)
-          @inverse = opts_or_string.delete(:inverse) || options.delete(:inverse)
           match_function(opts_or_string.merge(options))
         else
-          @inverse = options.delete(:inverse)
           match_function(options.merge('_all' => opts_or_string))
         end
       end
@@ -50,8 +48,14 @@ module Stretchy
       #   @param opts_or_string [Hash] Fields and values that should not match in the document
       # 
       # @return [BoostMatchClause] Query with inverse matching boost function applied
-      def not(opts_or_string = {}, options = {})
-        self.class.new(self, opts_or_string, options.merge(inverse: !inverse?))
+      def not(opts_or_string = {})
+        @inverse = true
+        if opts_or_string.is_a?(Hash)
+          match_function(opts_or_string)
+        else
+          match_function('_all' => opts_or_string)
+        end
+        self
       end
 
       # 

--- a/lib/stretchy/clauses/boost_where_clause.rb
+++ b/lib/stretchy/clauses/boost_where_clause.rb
@@ -21,8 +21,8 @@ module Stretchy
       # 
       # @return [BoostWhereClause] Query with filter boosts applied
       def initialize(base, options = {})
-        super(base, options)
-        where_function(:init, options)
+        super(base)
+        where_function(:init, options) if options.any?
         self
       end
 

--- a/lib/stretchy/clauses/match_clause.rb
+++ b/lib/stretchy/clauses/match_clause.rb
@@ -21,7 +21,11 @@ module Stretchy
       # 
       # @return [MatchClause] Temporary clause outside current state
       def self.tmp(options = {})
-        self.new(Base.new, options)
+        if options.delete(:inverse)
+          self.new(Base.new).not(options)
+        else
+          self.new(Base.new, options)
+        end
       end
 
       # 
@@ -77,8 +81,10 @@ module Stretchy
       #     my_field: "not_match_1",
       #     other_field: "not_match_2"
       #   )
-      def not(opts_or_str = {}, options = {})
-        self.class.new(self, opts_or_str, options.merge(inverse: true, should: should?))
+      def not(opts_or_str = {})
+        @inverse = true
+        add_params(opts_or_str)
+        self
       end
 
       # 
@@ -88,9 +94,9 @@ module Stretchy
       # 
       # Can be chained with {#not}
       # 
-      # @overload not(opts_or_str)
+      # @overload should(opts_or_str)
       #   @param [String] A string that should be matched anywhere in the document
-      # @overload not(opts_or_str)
+      # @overload should(opts_or_str)
       #   @param [Hash] A hash of fields and strings that should be matched in those fields
       # 
       # @param opts_or_str = {} [type] [description]
@@ -114,8 +120,11 @@ module Stretchy
       #   )
       # 
       # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html Elastic Docs - Bool Query
-      def should(opts_or_str = {}, options = {})
-        self.class.new(self, opts_or_str, options.merge(should: true))
+      def should(opts_or_str = {})
+        @should  = true
+        @inverse = false
+        add_params(opts_or_str)
+        self
       end
 
       # 

--- a/spec/stretchy/clauses/boost_clause_spec.rb
+++ b/spec/stretchy/clauses/boost_clause_spec.rb
@@ -4,16 +4,9 @@ describe Stretchy::Clauses::BoostClause do
   let(:base) { Stretchy::Clauses::Base.new }
   subject    { described_class.new(base) }
 
-  describe 'initialize with' do
-    specify 'base' do
-      instance = described_class.new(base)
-      expect(instance).to be_a(described_class)
-    end
-
-    specify 'inverse option' do
-      instance = described_class.new(base, inverse: true)
-      expect(instance.inverse?).to eq(true)
-    end
+  specify 'base' do
+    instance = described_class.new(base)
+    expect(instance).to be_a(described_class)
   end
 
   describe 'can add option' do

--- a/spec/stretchy/clauses/boost_match_clause_spec.rb
+++ b/spec/stretchy/clauses/boost_match_clause_spec.rb
@@ -14,11 +14,6 @@ describe Stretchy::Clauses::BoostMatchClause do
       expect(instance).to be_a(Stretchy::Clauses::Base)
     end
 
-    specify 'inverse option' do
-      instance = described_class.new(base, inverse: true)
-      expect(instance.inverse?).to eq(true)
-    end
-
     specify 'string' do
       instance = described_class.new(base, 'match all string')
       expect(instance.boost_builder.functions.count).to eq(1)
@@ -36,19 +31,6 @@ describe Stretchy::Clauses::BoostMatchClause do
       expect(boost.weight).to eq(default_weight)
     end
 
-    specify 'inverse string and options' do
-      instance = described_class.new(base, 'not all string', 
-        string_field: 'not field match',
-        inverse: true
-      )
-      expect(instance.inverse?).to eq(true)
-      expect(instance.boost_builder.functions.count).to eq(1)
-      boost = instance.boost_builder.functions.first
-      expect(boost).to be_a(boost_class)
-      expect(boost.filter).to be_a(filter_class)
-      expect(boost.weight).to eq(default_weight)
-    end
-
     specify 'string and weight' do
       instance = described_class.new(base, 'match all string', weight: 12)
       expect(instance.boost_builder.functions.count).to eq(1)
@@ -57,22 +39,11 @@ describe Stretchy::Clauses::BoostMatchClause do
       expect(boost.weight).to eq(12)
     end
 
-    specify 'string, inverse, and weight' do
-      instance = described_class.new(base, 'match all string', weight: 12, inverse: true)
-      expect(instance.inverse?).to eq(true)
-      expect(instance.boost_builder.functions.count).to eq(1)
-      boost = instance.boost_builder.functions.first
-      expect(boost.filter).to be_a(filter_class)
-      expect(boost.weight).to eq(12)
-    end
-
-    specify 'string, inverse, weight, and fields' do
+    specify 'string, weight, and fields' do
       instance = described_class.new(base, 'match all string', 
         weight: 12, 
-        inverse: true,
         string_field: 'match string field'
       )
-      expect(instance.inverse?).to eq(true)
       expect(instance.boost_builder.functions.count).to eq(1)
       boost = instance.boost_builder.functions.first
       expect(boost.filter).to be_a(filter_class)

--- a/spec/stretchy/clauses/boost_where_clause_spec.rb
+++ b/spec/stretchy/clauses/boost_where_clause_spec.rb
@@ -11,19 +11,8 @@ describe Stretchy::Clauses::BoostWhereClause do
       expect(instance).to be_a(Stretchy::Clauses::Base)
     end
 
-    specify 'inverse option' do
-      instance = described_class.new(base, inverse: true)
-      expect(instance.inverse?).to eq(true)
-    end
-
     specify 'params' do
       instance = described_class.new(base, number_field: 27)
-      expect(instance.boost_builder.functions).to include(Stretchy::Boosts::FilterBoost)
-    end
-
-    specify 'inverse params' do
-      instance = described_class.new(base, number_field: 27, inverse: true)
-      expect(instance.boost_builder.functions.count).to eq(1)
       expect(instance.boost_builder.functions).to include(Stretchy::Boosts::FilterBoost)
     end
   end

--- a/spec/stretchy/clauses/where_clause_spec.rb
+++ b/spec/stretchy/clauses/where_clause_spec.rb
@@ -37,42 +37,14 @@ describe Stretchy::Clauses::WhereClause do
       end
     end
 
-    specify 'inverse option' do
-      instance = described_class.new(base,
-        field_one: 27,
-        inverse: true
-      )
-      expect(instance.inverse?).to eq(true)
-      expect(instance.where_builder.antiterms[:field_one]).to include(27)
-
-      [:matches, :antimatches, :shouldmatches, :shouldnotmatches].each do |field|
-        expect(instance.match_builder.send(field)[:inverse]).to be_empty
-      end
-
-      [:terms, :shouldterms, :antiterms, :shouldnotterms].each do |field|
-        expect(instance.where_builder.send(field)[:inverse]).to be_empty
-      end
-    end
-
-    specify 'should option' do
-      instance = described_class.new(base,
-        field_one: 27,
-        should: true
-      )
-      expect(instance.should?).to eq(true)
-      expect(instance.where_builder.shouldterms[:field_one]).to include(27)
-
-      [:matches, :antimatches, :shouldmatches, :shouldnotmatches].each do |field|
-        expect(instance.match_builder.send(field)[:should]).to be_empty
-      end
-      
-      [:terms, :shouldterms, :antiterms, :shouldnotterms].each do |field|
-        expect(instance.where_builder.send(field)[:should]).to be_empty
-      end
-    end
-
     specify 'tmp' do
       expect(described_class.tmp).to be_a(described_class)
+    end
+
+    specify 'tmp with inverse option' do
+      instance = described_class.tmp(field_one: 1, inverse: true)
+      expect(instance.inverse?).to eq(true)
+      expect(instance.where_builder.antiterms[:field_one]).to include(1)
     end
   end
 


### PR DESCRIPTION
Calling `.where` from anywhere removes any `.not` or `.should` context. You always have to call `.where.not` or `.should.not` - order **matters** . This removes ambiguity in long query chains.