### PR TITLE
Refactor/params vs options

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ The `:scale` param determines how quickly the value falls off. In the example ab
 
 See the [Function Score Query](http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html) section on Decay Functions for more info.
 
+### Field
+
+```ruby
+query = query.boost.field(:popularity)
+             .boost.field(:timestamp, factor: 0.5, modifier: :sqrt)
+             .boost.field(:votes, :bookmarks, :comments)
+```
+
+Boosts a document by a numeric value contained in the specified fields. You can also specify a `factor` (an amount to multiply the field value by) and a `modifier` (a function for normalizing values).
+
+See the [Boosting By Popularity Guide](https://www.elastic.co/guide/en/elasticsearch/guide/current/boosting-by-popularity.html) and the [Field Value Factor documentation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_field_value_factor) for more info.
+
 ### Random
 
 ```ruby

--- a/lib/stretchy/boosts.rb
+++ b/lib/stretchy/boosts.rb
@@ -1,4 +1,5 @@
 require 'stretchy/boosts/base'
 require 'stretchy/boosts/field_decay_boost'
+require 'stretchy/boosts/field_value_boost'
 require 'stretchy/boosts/filter_boost'
 require 'stretchy/boosts/random_boost'

--- a/lib/stretchy/boosts/field_value_boost.rb
+++ b/lib/stretchy/boosts/field_value_boost.rb
@@ -1,0 +1,36 @@
+module Stretchy
+  module Boosts
+    class FieldValueBoost < Base
+
+      MODIFIERS = [:none, :log, :log1p, :log2p, :ln, :ln1p, :ln2p, :square, :sqrt, :reciprocal]
+
+      attribute :field
+      attribute :modifier
+      attribute :factor
+
+      validations do
+        rule :field, :field
+        rule :modifier, inclusion: {in: MODIFIERS}
+        rule :factor, type: {classes: Numeric}
+      end
+
+      def initialize(field, options = {})
+        @field    = field
+        @modifier = options[:modifier]
+        @factor   = options[:factor]
+        validate!
+      end
+
+      def to_search
+        json = { field: field }
+        json[:modifier] = modifier if modifier
+        json[:factor] = factor if factor
+        
+        {
+          field_value_factor: json
+        }
+      end
+
+    end
+  end
+end

--- a/lib/stretchy/builders/boost_builder.rb
+++ b/lib/stretchy/builders/boost_builder.rb
@@ -2,6 +2,10 @@ module Stretchy
   module Builders
     class BoostBuilder
 
+      extend Forwardable
+
+      delegate [:any?, :count, :length] => :functions
+
       attr_accessor :functions, :overall_boost, :max_boost, :score_mode, :boost_mode
 
       def initialize
@@ -12,8 +16,8 @@ module Stretchy
         @boost_mode     = 'sum'
       end
 
-      def any?
-        @functions.any?
+      def add_boost(boost)
+        @functions << boost
       end
 
       def to_search(query_or_filter)

--- a/lib/stretchy/builders/where_builder.rb
+++ b/lib/stretchy/builders/where_builder.rb
@@ -38,7 +38,6 @@ module Stretchy
         else
           geo_point = Types::GeoPoint.new(options)
         end
-        
         builder_from_options(options).add_geo(field, distance, geo_point)
       end
 

--- a/lib/stretchy/clauses/boost_clause.rb
+++ b/lib/stretchy/clauses/boost_clause.rb
@@ -50,6 +50,38 @@ module Stretchy
       end
       alias :filter :where
 
+
+      # 
+      # Adds a boost based on the value in the specified field.
+      # You can pass more than one field as arguments, and
+      # you can also pass the `factor` and `modifier` options
+      # as an options hash.
+      #
+      # **CAUTION:** All documents in the index _must_ have
+      # a numeric value for any fields specified here, or
+      # the query will fail.
+      #
+      # @example Adding two fields with options
+      #   query = query.boost.field(:numeric_field, :other_field, factor: 7, modifier: :log2p)
+      # 
+      # @param *args [Arguments] Fields to add to the document score
+      # @param options = {} [Hash] Options to pass to the field_value_factor boost
+      # 
+      # @return [self] Query state with field boosts applied
+      #
+      # @see https://www.elastic.co/guide/en/elasticsearch/guide/current/boosting-by-popularity.html Elasticsearch guide on boosting by popularity
+      #
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_field_value_factor Elasticsearch field value factor reference
+      # 
+      def field(*args)
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        args.each do |field|
+          pp 
+          base.boost_builder.add_boost(Boosts::FieldValueBoost.new(field, options))
+        end
+        self
+      end
+
       def not(*args)
         raise Errors::InvalidQueryError.new("Cannot call .not directly after boost - use .where.not or .match.not instead")
       end

--- a/lib/stretchy/clauses/boost_clause.rb
+++ b/lib/stretchy/clauses/boost_clause.rb
@@ -23,31 +23,17 @@ module Stretchy
       delegate [:geo, :range] => :where
 
       # 
-      # Switch to the boost state, specifying that
-      # the next where / range / etc will be a boost
-      # instead of a regular filter / range / etc.
-      # 
-      # @param base [Base] a clause to copy query state from
-      # @param options = {} [Hash] Options for the boost clause
-      # @option options [true, false] :inverse (nil) If this boost should also be in the inverse state
-      # 
-      def initialize(base)
-        super(base)
-      end
-
-      # 
       # Changes query state to "match" in the context
       # of boosting. Options here work the same way as
       # {MatchClause#initialize}, but the combined query
       # will be applied as a boost function.
       # 
-      # @param options = {} [Hash] options for full text matching
+      # @param params = {} [Hash] params for full text matching
       # 
       # @return [BoostMatchClause] query with boost match state
-      def match(options = {})
-        BoostMatchClause.new(base, options)
+      def match(params = {}, options = {})
+        BoostMatchClause.new(base).boost_match(params, options)
       end
-      alias :fulltext :match
 
       # 
       # Changes query state to "where" in the context
@@ -55,14 +41,18 @@ module Stretchy
       # but applies the generated filters as a boost
       # function. 
       # 
-      # @param options = {} [Hash] Filters to use in this boost.
+      # @param params = {} [Hash] Filters to use in this boost.
       # 
       # @return [BoostWhereClause] Query state with boost filters applied
       # 
-      def where(options = {})
-        BoostWhereClause.new(base, options)
+      def where(params = {}, options = {})
+        BoostWhereClause.new(base).boost_where(params, options)
       end
       alias :filter :where
+
+      def not(*args)
+        raise Errors::InvalidQueryError.new("Cannot call .not directly after boost - use .where.not or .match.not instead")
+      end
 
       # 
       # Adds a {Boosts::FieldDecayBoost}, which boosts
@@ -76,18 +66,18 @@ module Stretchy
       # * `:origin` or `:lat` & `:lng` combo
       # * `:scale`
       # 
-      # @option options [Numeric] :field What field to check with this boost
-      # @option options [Date, Time, Numeric, Types::GeoPoint] :origin Boost score based on how close the field is to this value. Required unless {Types::GeoPoint} is present (:lat, :lng, etc)
-      # @option options [Numeric] :lat Latitude, for a geo point
-      # @option options [Numeric] :latitude Latitude, for a geo point
-      # @option options [Numeric] :lng Longitude, for a geo point
-      # @option options [Numeric] :lon Longitude, for a geo point
-      # @option options [Numeric] :longitude Longitude, for a geo point
-      # @option options [String] :scale When the field is this distance from origin, the boost will be multiplied by `:decay` . Default is 0.5, so when `:origin` is a geo point and `:scale` is '10mi', then this boost will be twice as much for a point at the origin as for one 10 miles away
-      # @option options [String] :offset Anything within this distance of the origin is boosted as if it were at the origin
-      # @option options [Symbol] :type (:gauss) What type of decay to use. One of `:linear`, `:exp`, or `:gauss` 
-      # @option options [Numeric] :decay_amount (0.5) How much the boost falls off when it is `:scale` distance from `:origin`
-      # @option options [Numeric] :weight (1.2) How strongly to weight this boost compared to others
+      # @option params [Numeric] :field What field to check with this boost
+      # @option params [Date, Time, Numeric, Types::GeoPoint] :origin Boost score based on how close the field is to this value. Required unless {Types::GeoPoint} is present (:lat, :lng, etc)
+      # @option params [Numeric] :lat Latitude, for a geo point
+      # @option params [Numeric] :latitude Latitude, for a geo point
+      # @option params [Numeric] :lng Longitude, for a geo point
+      # @option params [Numeric] :lon Longitude, for a geo point
+      # @option params [Numeric] :longitude Longitude, for a geo point
+      # @option params [String] :scale When the field is this distance from origin, the boost will be multiplied by `:decay` . Default is 0.5, so when `:origin` is a geo point and `:scale` is '10mi', then this boost will be twice as much for a point at the origin as for one 10 miles away
+      # @option params [String] :offset Anything within this distance of the origin is boosted as if it were at the origin
+      # @option params [Symbol] :type (:gauss) What type of decay to use. One of `:linear`, `:exp`, or `:gauss` 
+      # @option params [Numeric] :decay_amount (0.5) How much the boost falls off when it is `:scale` distance from `:origin`
+      # @option params [Numeric] :weight (1.2) How strongly to weight this boost compared to others
       # 
       # @example Boost near a geo point
       #   query.boost.near(
@@ -105,7 +95,7 @@ module Stretchy
       #     scale: '3d'
       #   )
       # 
-      # @example Boost near a number (with options)
+      # @example Boost near a number (with params)
       #   query.boost.near(
       #     field: :followers,
       #     origin: 100,
@@ -119,13 +109,13 @@ module Stretchy
       # @return [Base] Query with field decay filter added
       # 
       # @see http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html Elastic Docs - Function Score Query
-      def near(options = {})
-        if options[:lat] || options[:latitude]  ||
-           options[:lng] || options[:longitude] || options[:lon]
+      def near(params = {}, options = {})
+        if params[:lat] || params[:latitude]  ||
+           params[:lng] || params[:longitude] || params[:lon]
 
-          options[:origin] = Stretchy::Types::GeoPoint.new(options)
+          params[:origin] = Stretchy::Types::GeoPoint.new(params)
         end
-        base.boost_builder.functions << Stretchy::Boosts::FieldDecayBoost.new(options)
+        base.boost_builder.add_boost Stretchy::Boosts::FieldDecayBoost.new(params)
         Base.new(base)
       end
       alias :geo :near
@@ -188,17 +178,6 @@ module Stretchy
       # @return [self] Boost context with boost mode applied
       def boost_mode(mode)
         base.boost_builder.boost_mode = mode
-        self
-      end
-
-      # 
-      # Switches to inverse context - boosts added with {#where} 
-      # and #{match} will be applied to documents which *do not*
-      # match said filters.
-      # 
-      # @return [BoostClause] Boost clause in inverse context
-      def not(options = {})
-        @inverse = true
         self
       end
 

--- a/lib/stretchy/errors.rb
+++ b/lib/stretchy/errors.rb
@@ -1,1 +1,2 @@
 require 'stretchy/errors/validation_error.rb'
+require 'stretchy/errors/invalid_query_error.rb'

--- a/lib/stretchy/errors/invalid_query_error.rb
+++ b/lib/stretchy/errors/invalid_query_error.rb
@@ -1,0 +1,6 @@
+module Stretchy
+  module Errors
+    class InvalidQueryError < StandardError
+    end
+  end
+end

--- a/spec/integration/field_value_spec.rb
+++ b/spec/integration/field_value_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'boosting by field value' do
+
+  let(:found)      { fixture(:sakurai) }
+  let(:not_found)  { fixture(:mizuguchi) }
+
+  subject { Stretchy.query(index: SPEC_INDEX, type: FIXTURE_TYPE) }
+
+  it 'boosts by who has the highest salary' do
+    ids = subject.boost.field(:salary).ids
+    expect(ids.index(found['id'])).to be < ids.index(not_found['id'])
+  end
+
+end

--- a/spec/stretchy/boosts/field_value_boost_spec.rb
+++ b/spec/stretchy/boosts/field_value_boost_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Stretchy::Boosts::FieldValueBoost do
+
+  it 'initializes with field' do
+    inst = described_class.new(:my_field)
+    expect(inst.field).to eq(:my_field)
+  end
+
+  it 'initializes with options' do
+    inst = described_class.new(:my_field, factor: 9001, modifier: :log2p)
+    expect(inst.factor).to eq(9001)
+    expect(inst.modifier).to eq(:log2p)
+  end
+
+  it 'serializes options' do
+    inst = described_class.new(:my_field, factor: 9001, modifier: :log2p)
+    expect(inst.to_search).to eq({
+      field_value_factor: {
+        field: :my_field,
+        factor: 9001,
+        modifier: :log2p
+      }
+    })
+  end
+
+end

--- a/spec/stretchy/clauses/base_spec.rb
+++ b/spec/stretchy/clauses/base_spec.rb
@@ -20,25 +20,25 @@ describe Stretchy::Clauses::Base do
 
   it 'delegates not() to MatchClause with string arguments' do
     not_string = 'not match string'
-    expect_any_instance_of(Stretchy::Clauses::MatchClause).to receive(:not).with(not_string)
+    expect_any_instance_of(Stretchy::Clauses::MatchClause).to receive(:not).with(not_string, {})
     subject.not(not_string)
   end
 
   it 'delegates not() to WhereClause with hash arguments' do
     not_hash = {field: 'string'}
-    expect_any_instance_of(Stretchy::Clauses::WhereClause).to receive(:not).with(not_hash)
+    expect_any_instance_of(Stretchy::Clauses::WhereClause).to receive(:not).with(not_hash, {})
     subject.not(not_hash)
   end
 
   it 'delegates should() to MatchClause with string arguments' do
     string = 'match string'
-    expect_any_instance_of(Stretchy::Clauses::MatchClause).to receive(:should).with(string)
+    expect_any_instance_of(Stretchy::Clauses::MatchClause).to receive(:should).with(string, {})
     subject.should(string)
   end
 
   it 'delegates should() to WhereClause with hash arguments' do
     hash = {field: 'field string'}
-    expect_any_instance_of(Stretchy::Clauses::WhereClause).to receive(:should).with(hash)
+    expect_any_instance_of(Stretchy::Clauses::WhereClause).to receive(:should).with(hash, {})
     subject.should(hash)
   end
 

--- a/spec/stretchy/clauses/boost_clause_spec.rb
+++ b/spec/stretchy/clauses/boost_clause_spec.rb
@@ -39,6 +39,41 @@ describe Stretchy::Clauses::BoostClause do
       expect(subject.match).to be_a(Stretchy::Clauses::BoostMatchClause)
     end
 
+    describe 'field' do
+      specify 'single field' do
+        clause = subject.field(:salary)
+        fn = clause.base.boost_builder.functions.first
+
+        expect(fn).to be_a(Stretchy::Boosts::FieldValueBoost)
+        expect(fn.field).to eq(:salary)
+        expect(fn.modifier).to be_nil
+        expect(fn.factor).to be_nil
+      end
+
+      specify 'multiple fields' do
+        clause = subject.field(:salary, :number_two, :number_three)
+        expect(clause.base.boost_builder.functions.count).to eq(3)
+      end
+
+      specify 'field with factor and modifier' do
+        clause = subject.field(:salary, factor: 2, modifier: :log2p)
+        fn = clause.base.boost_builder.functions.first
+        expect(fn.factor).to eq(2)
+        expect(fn.modifier).to eq(:log2p)
+      end
+
+      specify 'multiple fields with factor and modifier' do
+        clause = subject.field(:salary, :number_two, :number_three, factor: 2, modifier: :log2p)
+        fn = clause.base.boost_builder.functions.first
+        expect(fn.factor).to eq(2)
+        expect(fn.modifier).to eq(:log2p)
+      end
+
+      specify 'only with valid modifier' do
+        expect{subject.field(:salary, modifier: :wat?)}.to raise_error
+      end
+    end
+
     describe 'near' do
 
       specify 'geo point' do

--- a/spec/stretchy/clauses/boost_clause_spec.rb
+++ b/spec/stretchy/clauses/boost_clause_spec.rb
@@ -31,10 +31,6 @@ describe Stretchy::Clauses::BoostClause do
       expect(subject.boost_mode('avg').base.boost_builder.boost_mode).to eq('avg')
     end
 
-    specify 'not' do
-      expect(subject.not.inverse?).to eq(true)
-    end
-
     specify 'where' do
       expect(subject.where).to be_a(Stretchy::Clauses::BoostWhereClause)
     end

--- a/spec/stretchy/clauses/boost_match_clause_spec.rb
+++ b/spec/stretchy/clauses/boost_match_clause_spec.rb
@@ -13,17 +13,19 @@ describe Stretchy::Clauses::BoostMatchClause do
       expect(instance).to be_a(Stretchy::Clauses::BoostClause)
       expect(instance).to be_a(Stretchy::Clauses::Base)
     end
+  end
 
+  describe 'can match with' do
     specify 'string' do
-      instance = described_class.new(base, 'match all string')
+      instance = described_class.new(base).boost_match('match all string')
       expect(instance.base.boost_builder.functions.count).to eq(1)
       boost = instance.base.boost_builder.functions.first
       expect(boost.filter).to be_a(filter_class)
       expect(boost.weight).to eq(default_weight)
     end
 
-    specify 'string and options' do
-      instance = described_class.new(base, 'match all string', string_field: 'string field matcher')
+    specify 'field and value parameters' do
+      instance = described_class.new(base).boost_match(string_field: 'string field matcher')
       expect(instance.base.boost_builder.functions.count).to eq(1)
       boost = instance.base.boost_builder.functions.first
       expect(boost).to be_a(boost_class)
@@ -32,7 +34,7 @@ describe Stretchy::Clauses::BoostMatchClause do
     end
 
     specify 'string and weight' do
-      instance = described_class.new(base, 'match all string', weight: 12)
+      instance = described_class.new(base).boost_match('match all string', weight: 12)
       expect(instance.base.boost_builder.functions.count).to eq(1)
       boost = instance.base.boost_builder.functions.first
       expect(boost.filter).to be_a(filter_class)
@@ -40,14 +42,15 @@ describe Stretchy::Clauses::BoostMatchClause do
     end
 
     specify 'string, weight, and fields' do
-      instance = described_class.new(base, 'match all string', 
-        weight: 12, 
-        string_field: 'match string field'
+      instance = described_class.new(base).boost_match('match all string', 
+        weight: 12,
+        type: :phrase
       )
       expect(instance.base.boost_builder.functions.count).to eq(1)
       boost = instance.base.boost_builder.functions.first
       expect(boost.filter).to be_a(filter_class)
       expect(boost.weight).to eq(12)
+      expect(boost.filter.query.type).to eq('phrase')
     end
   end
 

--- a/spec/stretchy/clauses/boost_where_clause_spec.rb
+++ b/spec/stretchy/clauses/boost_where_clause_spec.rb
@@ -10,9 +10,11 @@ describe Stretchy::Clauses::BoostWhereClause do
       expect(instance).to be_a(Stretchy::Clauses::BoostClause)
       expect(instance).to be_a(Stretchy::Clauses::Base)
     end
+  end
 
+  describe 'can boost params' do
     specify 'params' do
-      instance = described_class.new(base, number_field: 27)
+      instance = described_class.new(base).boost_where(number_field: 27)
       expect(instance.base.boost_builder.functions).to include(Stretchy::Boosts::FilterBoost)
     end
   end

--- a/spec/stretchy/clauses/match_clause_spec.rb
+++ b/spec/stretchy/clauses/match_clause_spec.rb
@@ -6,33 +6,11 @@ describe Stretchy::Clauses::MatchClause do
   let(:match_builder) { Stretchy::Builders::MatchBuilder }
   subject { described_class.new(base) }
 
-  it 'creates a temporary instance' do
-    expect(described_class.tmp).to be_a(described_class)
-  end
-
   context 'initializes with' do
     specify 'nil' do
       instance = described_class.new(base)
       expect(instance.inverse?).to eq(false)
       expect(instance.should?).to eq(false)
-    end
-
-    specify 'string' do
-      expect_any_instance_of(match_builder).to receive(:add_matches).with(
-        '_all', 'match string', {}
-      )
-      described_class.new(base, 'match string')
-    end
-
-    specify 'options' do
-      expect_any_instance_of(match_builder).to receive(:add_matches).with(
-        :field_one, 'one', {}
-      )
-
-      expect_any_instance_of(match_builder).to receive(:add_matches).with(
-        :field_two, 'two', {}
-      )
-      described_class.new(base, field_one: 'one', field_two: 'two')
     end
   end
 
@@ -112,7 +90,7 @@ describe Stretchy::Clauses::MatchClause do
     )
 
     expect_any_instance_of(match_builder).to receive(:add_matches).with(
-      '_all', 'match all', {}
+      '_all', 'match all', {should: true}
     )
     subject.should(field_one: 'one').match('match all')
   end
@@ -144,7 +122,7 @@ describe Stretchy::Clauses::MatchClause do
     )
 
     expect_any_instance_of(match_builder).to receive(:add_matches).with(
-      '_all', 'match all', {}
+      '_all', 'match all', {inverse: true, should: true}
     )
 
     subject.should(field_one: 'one').not(field_two: 'two').match('match all')

--- a/spec/stretchy/clauses/where_clause_spec.rb
+++ b/spec/stretchy/clauses/where_clause_spec.rb
@@ -11,49 +11,6 @@ describe Stretchy::Clauses::WhereClause do
       expect(instance.inverse?).to eq(false)
       expect(instance.should?).to eq(false)
     end
-
-    specify 'params' do
-      expect_any_instance_of(match_builder).to receive(:add_matches).with(
-        :field_one, 'one', {}
-      )
-
-      expect_any_instance_of(match_builder).to receive(:add_matches).with(
-        :symbol_field, :my_symbol, {}
-      )
-
-      expect_any_instance_of(where_builder).to receive(:add_param).with(
-        :nil_field, nil, {}
-      )
-
-      expect_any_instance_of(where_builder).to receive(:add_param).with(
-        :range_field, 27..34, {}
-      )
-
-      expect_any_instance_of(where_builder).to receive(:add_param).with(
-        :number_field, 86, {}
-      )
-      
-      described_class.new(base,
-        field_one: 'one',
-        nil_field: nil,
-        range_field: 27..34,
-        number_field: 86,
-        symbol_field: :my_symbol
-      )
-    end
-
-    specify 'tmp' do
-      expect(described_class.tmp).to be_a(described_class)
-    end
-
-    specify 'tmp with inverse option' do
-      expect_any_instance_of(where_builder).to receive(:add_param).with(
-        :field_one, 1,
-        inverse: true
-      )
-      instance = described_class.tmp(field_one: 1, inverse: true)
-      expect(instance.inverse?).to eq(true)
-    end
   end
 
   describe 'can add a' do
@@ -126,6 +83,7 @@ describe Stretchy::Clauses::WhereClause do
       expect_any_instance_of(where_builder).to receive(:add_param).with(
         :where_field, 42, {}
       )
+
       subject.should.not(not_field: 27).should(should_field: 33).where(where_field: 42)
     end
 
@@ -162,7 +120,7 @@ describe Stretchy::Clauses::WhereClause do
   end
 
   it 'converts to boost' do
-    instance = described_class.new(base,
+    instance = described_class.new(base).where(
       number_field: 27,
       string_field: 'hello',
       nil_field: nil,


### PR DESCRIPTION
Allow passing options to individual query parts in addition to ActiveRecord-like query params.

Also, add the field value factor boost.