### PR TITLE
Fix .boost.fulltext to set match type params

### DIFF
--- a/lib/stretchy/builders/query_builder.rb
+++ b/lib/stretchy/builders/query_builder.rb
@@ -21,7 +21,7 @@ module Stretchy
       def add_matches(field, new_matches, options = {})
         @matches[field] += Array(new_matches)
         opts = {}
-        [:operator, :slop, :minimum_should_match, :type].each do |opt|
+        [:operator, :slop, :minimum_should_match, :min, :type].each do |opt|
           opts[opt] = options[opt] if options[opt]
         end
         @query_opts[field] = opts

--- a/lib/stretchy/clauses/boost_clause.rb
+++ b/lib/stretchy/clauses/boost_clause.rb
@@ -21,6 +21,7 @@ module Stretchy
       extend Forwardable
 
       delegate [:geo, :range] => :where
+      delegate [:fulltext]    => :match
 
       # 
       # Changes query state to "match" in the context
@@ -32,7 +33,9 @@ module Stretchy
       # 
       # @return [BoostMatchClause] query with boost match state
       def match(params = {}, options = {})
-        BoostMatchClause.new(base).boost_match(params, options)
+        clause = BoostMatchClause.new(base)
+        clause = clause.boost_match(params, options) unless params.empty? && options.empty?
+        clause
       end
 
       # 

--- a/lib/stretchy/clauses/boost_match_clause.rb
+++ b/lib/stretchy/clauses/boost_match_clause.rb
@@ -37,10 +37,12 @@ module Stretchy
       end
 
       def fulltext(params = {}, options = {})
-        weight = params.delete(:weight) || options[:weight]
-        options[:min] = 1
-        options[:slop] = MatchClause::FULLTEXT_SLOP
-        clause = MatchClause.new.match(params, options)
+        _params = hashify_params(params)
+        weight = _params.delete(:weight) || options[:weight]
+        options[:min]  ||= MatchClause::FULLTEXT_MIN
+        options[:slop] ||= MatchClause::FULLTEXT_SLOP
+        options[:type] ||= Queries::MatchQuery::MATCH_TYPES.first
+        clause = MatchClause.new.match(_params, options)
         boost  = clause.to_boost(weight)
         base.boost_builder.add_boost(boost) if boost
         Base.new(base)
@@ -83,7 +85,7 @@ module Stretchy
       private
 
         def match_function(params = {}, options = {})
-          weight = params.delete(:weight) || options[:weight]
+          weight = hashify_params(params).delete(:weight) || options[:weight]
           clause = MatchClause.new.match(params, options)
           boost  = clause.to_boost(weight)
           base.boost_builder.add_boost(boost) if boost

--- a/lib/stretchy/queries/match_query.rb
+++ b/lib/stretchy/queries/match_query.rb
@@ -12,7 +12,7 @@ module Stretchy
       attribute :operator,  String
       attribute :type,      String
       attribute :slop,      Integer
-      attribute :min,       String
+      attribute :min,       Integer
       attribute :max,       Float
 
       validations do
@@ -24,6 +24,10 @@ module Stretchy
         rule :slop,      type: Numeric
         rule :min,      :min_should_match
         rule :max,       type: Numeric
+      end
+
+      def after_initialize(params)
+        @min ||= params[:minimum_should_match]
       end
 
       def option_attributes

--- a/lib/stretchy/utils/validation.rb
+++ b/lib/stretchy/utils/validation.rb
@@ -59,8 +59,8 @@ module Stretchy
         def initialize(attributes = nil)
           self.class.attribute_set.set(self, attributes) if attributes
           set_default_attributes
-          validate!
           after_initialize(attributes) if respond_to?(:after_initialize)
+          validate!
         end
 
       end


### PR DESCRIPTION
Also, stop adding a boost for `MatchAllQuery` if you call `.boost.match.whatever`

code review @christospappas ?