### PR TITLE
Clarify use of "exclusive" params in range()

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,10 @@ Stretchy tries to merge together filters on the same fields to optimize the fina
 query = query.range(:rating, min: 3, max: 5)
              .range(:released, min: Time.now - 60*60*24*100)
              .range(:quantity, max: 100, exclusive: true)
+             .range(:awesomeness, min: 89, max: 100, exclusive_min: true)
 ```
 
-Only documents with the specified field, and within the specified range match. You can also pass in dates and times as ranges. While you could pass a normal ruby `Range` object to `.where`, this allows you to specify only a minimum or only a maximum. Range filters are inclusive by default, but you can also pass `:exclusive`, `:exclusive_min`, or `:exclusive_max`.
+Only documents with the specified field, and within the specified range match. You can also pass in dates and times as ranges. While you could pass a normal ruby `Range` object to `.where`, this allows you to specify only a minimum or only a maximum. Range filters are inclusive by default, but you can also pass `:exclusive`, `:exclusive_min`, or `:exclusive_max`, which are flags declaring either or both of the `min` & `max` parameters to be exclusive.
 
 ### <a id="geo-distance"></a>Geo Distance
 

--- a/spec/stretchy/filters/range_filter_spec.rb
+++ b/spec/stretchy/filters/range_filter_spec.rb
@@ -15,11 +15,26 @@ describe Stretchy::Filters::RangeFilter do
     subject.new(*args).to_search[:range]
   end
 
-  it 'returns json for range filter' do
-    result = get_result(field, min: min, max: max)
-    expect(result[field]).to be_a(Hash)
-    expect(result[field][:gte]).to eq(min)
-    expect(result[field][:lte]).to eq(max)
+  describe 'returns json for range filter' do
+    specify "inclusive range" do
+      result = get_result(field, min: min, max: max)
+      expect(result[field]).to match({ gte: min, lte: max })
+    end
+
+    specify "exclusive range" do
+      result = get_result(field, exclusive: true, min: min, max: max)
+      expect(result[field]).to match({ gt: min, lt: max })
+    end
+
+    specify "exclusive range operators" do
+      result = get_result(field, exclusive_min: true, min: min, exclusive_max: max, max: max)
+      expect(result[field]).to match({ gt: min, lt: max })
+    end
+
+    specify "mixed range operators" do
+      result = get_result(field, exclusive_min: min, min: min, max: max)
+      expect(result[field]).to match({ gt: min, lte: max })
+    end
   end
 
   it 'accepts dates for min / max' do


### PR DESCRIPTION
After spending a while trying and failing to get the `exclusive` params in `query.range()` to work, I added some tests and prodded the code with a view to fixing it, then realised that I'd misunderstood the docs. This patch adds a little clarification to the README along with a couple more spec examples.