### PR TITLE
Do not call results from method_missing

### DIFF
--- a/lib/stretchy/api.rb
+++ b/lib/stretchy/api.rb
@@ -11,6 +11,21 @@ module Stretchy
 
     attr_reader :collector, :root, :context
 
+    delegate [
+      :total,
+      :total_count,
+      :length,
+      :size,
+      :total_pages,
+      :results,
+      :hits,
+      :to_a,
+      :ids,
+      :scores,
+      :explanations,
+      :aggregations
+    ] => :results_obj
+
     def initialize(options = {})
       @collector  = AndCollector.new(options[:nodes] || [], query: true)
       @root       = options[:root]     || {}
@@ -154,10 +169,12 @@ module Stretchy
       @results ||= Results.new request, response
     end
 
+    def count
+      results_obj.ids.count
+    end
+
     def method_missing(method, *args, &block)
-      if results_obj.respond_to?(method)
-        results_obj.send(method, *args, &block)
-      elsif collector.respond_to?(method)
+      if collector.respond_to?(method)
         collector.send(method, *args, &block)
       else
         super

--- a/lib/stretchy/factory.rb
+++ b/lib/stretchy/factory.rb
@@ -76,6 +76,7 @@ module Stretchy
 
     def params_to_queries(params, context = default_context)
       params.map do |field, val|
+        val = val.join if val.is_a? Array
         Node.new({match: {field => val}}, context)
       end
     end

--- a/spec/integration/query_spec.rb
+++ b/spec/integration/query_spec.rb
@@ -21,6 +21,11 @@ describe 'Queries' do
     check subject.match('sakurai')
   end
 
+  specify 'array match query' do
+    names = [found['name'], extra['name']]
+    check subject.match(name: names)
+  end
+
   specify 'basic filter' do
     check subject.query(term: { url_slug: found['url_slug']})
   end

--- a/spec/stretchy/api_spec.rb
+++ b/spec/stretchy/api_spec.rb
@@ -64,5 +64,14 @@ module Stretchy
 
     end
 
+    describe '#filter_node' do
+      subject { api.match(name: 'sakurai') }
+
+      it 'does build response before checking with collector' do
+        expect_any_instance_of(API).not_to receive(:results_obj)
+        subject.filter_node.json
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This was resulting in fetching results before they were actually needed. Use explicit `delegate` instead when we need the actual results to calculate a value. Harder to keep the two objects in sync, but far less stupid generally.

Also, allow arrays in `.match()`