### PR TITLE
Allow nested hashes in .where() and .match()

### DIFF
--- a/lib/stretchy/api.rb
+++ b/lib/stretchy/api.rb
@@ -81,12 +81,16 @@ module Stretchy
     end
 
     def where(params = {})
-      add_params params, :filter, :context_nodes
+      subcontext = {filter: true}
+      subcontext[:nested] = params.delete(:nested) if params[:nested]
+      add_params params, subcontext, :context_nodes
     end
 
     def match(params = {})
       if params.is_a? Hash
-        add_params params, :query, :context_nodes
+        subcontext = {query: true}
+        subcontext[:nested] = true if params.delete(:nested)
+        add_params params, subcontext, :context_nodes
       else
         add_params Hash[_all: params], :query, :context_nodes
       end

--- a/lib/stretchy/errors.rb
+++ b/lib/stretchy/errors.rb
@@ -1,4 +1,6 @@
 module Stretchy
-  class InvalidParamsError < StandardError; end
-  class IndexDoesNotExistError < StandardError ; end
+  module Errors
+    class InvalidParamsError < StandardError; end
+    class IndexDoesNotExistError < StandardError ; end
+  end
 end

--- a/spec/factory_spec.rb
+++ b/spec/factory_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+module Stretchy
+  describe Factory do
+
+    subject { described_class }
+
+    it "is pending an example"
+
+  end
+end

--- a/spec/fixtures/mappings_stub.json
+++ b/spec/fixtures/mappings_stub.json
@@ -1,0 +1,27 @@
+{
+  "game_dev" : {
+    "properties" : {
+      "coords" : {"type" : "geo_point"},
+      "url_slug" : {"type" : "string", "index" : "not_analyzed"},
+      "games" : {
+        "type" : "nested",
+        "include_in_parent" : true,
+        "properties" : {
+          "comments" : {
+            "type" : "nested",
+            "properties" : {
+              "source" : {
+                "type" : "string",
+                "index" : "not_analyzed"
+              }
+            }
+          },
+          "likes" : {
+            "type" : "nested",
+            "include_in_parent" : true
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/fixtures/mizuguchi.json
+++ b/spec/fixtures/mizuguchi.json
@@ -12,7 +12,21 @@
     {
       "id" : 8,
       "title" : "Rez",
-      "platforms" : ["Dreamcast"]
+      "platforms" : ["Dreamcast"],
+       "comments" : [
+        {
+          "user_id" : 3,
+          "user_name" : "stacy",
+          "comment" : "this game rocks",
+          "source" : "web"
+        },
+        {
+          "user_id" : 7,
+          "user_name" : "ulysses",
+          "comment" : "what is this i am not good with computer",
+          "source" : "mobile"
+        }
+      ]
     },
     {
       "id" : 9,
@@ -22,7 +36,10 @@
     {
       "id" : 10,
       "title" : "Child of Eden",
-      "platforms" : ["Xbox 360", "PlayStation 3"]
+      "platforms" : ["Xbox 360", "PlayStation 3"],
+      "likes" : [
+        {"user_id" : 7, "user" : "ulysses"}
+      ]
     }
   ],
   "location" : "Sendai, Japan",

--- a/spec/fixtures/sakurai.json
+++ b/spec/fixtures/sakurai.json
@@ -11,12 +11,30 @@
     {
       "id" : 1,
       "title" : "Super Smash Bros",
-      "platforms" : ["Nintendo 64"]
+      "platforms" : ["Nintendo 64"],
+      "comments" : [
+        {
+          "user_id" : 3,
+          "user_name" : "stacy",
+          "comment" : "yay awesome!",
+          "source" : "mobile"
+        },
+        {
+          "user_id" : 7,
+          "user_name" : "ulysses",
+          "comment" : "how is babby formed",
+          "source" : "web"
+        }
+      ]
     },
     {
       "id" : 2,
       "title" : "Smash Bros Melee",
-      "platforms" : ["GameCube"]
+      "platforms" : ["GameCube"],
+      "likes" : [
+        {"user_id" : 3, "user" : "stacy"},
+        {"user_id" : 7, "user" : "ulysses"}
+      ]
     },
     {
       "id" : 3,

--- a/spec/integration/boost_spec.rb
+++ b/spec/integration/boost_spec.rb
@@ -1,39 +1,29 @@
 require 'spec_helper'
 
-describe 'Boosts' do
-  let(:found) { fixture(:sakurai) }
-  let(:not_found) { fixture(:mizuguchi) }
-  let(:extra) { fixture(:suda) }
-
-  subject { Stretchy.query(index: SPEC_INDEX, type: FIXTURE_TYPE) }
-
-  def check(api)
-    expect(api.scores[found['id']]).to be > api.scores[not_found['id']]
-  end
-
+describe 'Boosts', :integration do
   specify 'filter' do
-    check subject.boost.filter(term: {url_slug: found['url_slug']}, weight: 10)
+    check_boost subject.boost.filter(term: {url_slug: found['url_slug']}, weight: 10)
   end
 
   specify 'query' do
-    check subject.boost.query(match: {_all: found['name']}, weight: 10)
+    check_boost subject.boost.query(match: {_all: found['name']}, weight: 10)
   end
 
   specify 'where' do
-    check subject.boost.where(url_slug: found['url_slug'])
+    check_boost subject.boost.where(url_slug: found['url_slug'])
   end
 
   specify 'match' do
-    check subject.boost.match(_all: found['name'])
+    check_boost subject.boost.match(_all: found['name'])
   end
 
   describe 'field value' do
     specify 'with only field' do
-      check subject.boost.field_value(field: :salary)
+      check_boost subject.boost.field_value(field: :salary)
     end
 
     specify 'with field value options' do
-      check subject.boost.field_value(
+      check_boost subject.boost.field_value(
         field:    :salary,
         factor:   1.2,
         modifier: :square
@@ -41,7 +31,7 @@ describe 'Boosts' do
     end
 
     specify 'with weight' do
-      check subject.boost.field_value(
+      check_boost subject.boost.field_value(
         field:  :salary,
         factor: 1.2,
         weight: 100
@@ -52,16 +42,16 @@ describe 'Boosts' do
   describe 'random value' do
     # fortunately, 'random' has a seed
     specify 'by seed' do
-      check subject.boost.random(found['id'])
+      check_boost subject.boost.random(found['id'])
     end
 
     specify 'with weight' do
-      check subject.boost.random(seed: found['id'], weight: 100)
+      check_boost subject.boost.random(seed: found['id'], weight: 100)
     end
   end
 
   specify 'distance from value' do
-    check subject.boost.near(
+    check_boost subject.boost.near(
       decay_function: :gauss,
       field: :coords,
       origin: found['coords'],
@@ -71,11 +61,11 @@ describe 'Boosts' do
   end
 
   specify 'not filter' do
-    check subject.boost.where.not(url_slug: not_found['url_slug'])
+    check_boost subject.boost.where.not(url_slug: not_found['url_slug'])
   end
 
   specify 'not matching' do
-    check subject.boost.match.not(name: not_found['name'])
+    check_boost subject.boost.match.not(name: not_found['name'])
   end
 
   describe 'function_score options' do

--- a/spec/integration/filter_spec.rb
+++ b/spec/integration/filter_spec.rb
@@ -1,71 +1,66 @@
 require 'spec_helper'
 
-describe 'Filters' do
-  let(:found) { fixture(:sakurai) }
-  let(:not_found) { fixture(:mizuguchi) }
-  let(:extra) { fixture(:suda) }
-
-  subject { Stretchy.query(index: SPEC_INDEX, type: FIXTURE_TYPE) }
-
-  def check(api)
-    ids = api.ids
-    expect(ids).to include(found['id'])
-    expect(ids).to_not include(not_found['id'])
-
-    # filters do not affect document scores, so make sure this
-    # is running filters
-    scores = api.scores.values
-    expect(scores.all?{|s| s == scores.first}).to eq(true)
-  end
-
+describe 'Filters', :integration do
   specify 'basic filter' do
-    check(subject.filter(terms: {id: [found['id'], extra['id']]}))
+    check_filter subject.filter(terms: {id: [found['id'], extra['id']]})
   end
 
   specify 'multiple filters' do
-    check subject.filter(terms: {id: [found['id'], extra['id']]})
+    check_filter subject.filter(terms: {id: [found['id'], extra['id']]})
                  .filter(term: {url_slug: found['url_slug']})
   end
 
   specify 'not filter' do
-    check subject.not.filter(term: {id: not_found['id']})
+    check_filter subject.not.filter(term: {id: not_found['id']})
   end
 
   # these are kind of useless except minimum_should_match
   specify 'should filters' do
-    check subject.should.filter(terms: {id: [found['id'], extra['id']]})
+    check_filter subject.should.filter(terms: {id: [found['id'], extra['id']]})
                  .should.filter(term: {url_slug: found['url_slug']})
   end
 
   specify 'query filter' do
-    check subject.filter.query(match: {_all: 'Gamecube'})
+    check_filter subject.filter.query(match: {_all: 'Gamecube'})
   end
 
   describe 'where filters' do
     let(:salary_range) { (found['salary'] - 5000)..(found['salary'] + 5000) }
 
     specify 'term string' do
-      check subject.where(url_slug: found['url_slug'])
+      check_filter subject.where(url_slug: found['url_slug'])
     end
 
     specify 'term symbol' do
-      check subject.where(url_slug: found['url_slug'].to_sym)
+      check_filter subject.where(url_slug: found['url_slug'].to_sym)
     end
 
-    specify 'multiple terms' do
-      check subject.where(url_slug: [found['url_slug'], 'not-a-slug'])
+    specify 'array terms' do
+      check_filter subject.where(url_slug: [found['url_slug'], 'not-a-slug'])
     end
 
     specify 'range' do
-      check subject.where(salary: salary_range)
+      check_filter subject.where(salary: salary_range)
     end
 
     specify 'nil' do
-      check subject.where(is_mizuguchi: nil)
+      check_filter subject.where(is_mizuguchi: nil)
+    end
+
+    describe 'nested hash filters' do
+      specify 'dotted hash terms query' do
+        check_filter subject.where(games: {id: [1,2]})
+      end
+
+      specify 'nested hash terms query' do
+        check_filter subject.where(nested: true, games: {
+          comments: {user_id: 3, source: "mobile"}
+        })
+      end
     end
 
     specify 'together' do
-      check subject.where(
+      check_filter subject.where(
         url_slug:     found['url_slug'],
         salary:       salary_range,
         is_mizuguchi: nil
@@ -74,11 +69,11 @@ describe 'Filters' do
   end
 
   specify 'range filter' do
-    check subject.filter.range(salary: {gte: found['salary']})
+    check_filter subject.filter.range(salary: {gte: found['salary']})
   end
 
   specify 'geo distance filter' do
-    check subject.geo_distance(
+    check_filter subject.geo_distance(
       distance: '1mi',
       coords: [found['coords']['lon'], found['coords']['lat']]
     )

--- a/spec/integration/query_spec.rb
+++ b/spec/integration/query_spec.rb
@@ -1,37 +1,43 @@
 require 'spec_helper'
 
-describe 'Queries' do
-  let(:found) { fixture(:sakurai) }
-  let(:not_found) { fixture(:mizuguchi) }
-  let(:extra) { fixture(:suda) }
+describe 'Queries', :integration do
+  specify 'basic query' do
+    check_query subject.query(match: { name: "sakurai"})
+  end
 
-  subject { Stretchy.query(index: SPEC_INDEX, type: FIXTURE_TYPE) }
+  describe 'match filters' do
+    specify 'string query' do
+      check_query subject.match('sakurai')
+    end
 
-  def check(api)
-    ids = api.ids
-    expect(ids).to include(found['id'])
-    expect(ids).to_not include(not_found['id'])
+    specify 'hash query' do
+      check_query subject.match(name: 'sakurai')
+    end
+
+    specify 'array match query' do
+      companies = [found['company'], extra['company']]
+      check_query subject.match(company: companies)
+    end
+
+    describe 'nested hash queries' do
+      specify 'dotted hash match query' do
+        check_query subject.match(games: {likes: {user: 'stacy'}})
+      end
+
+      specify 'nested hash match query' do
+        check_query subject.match(nested: true,
+          games: {comments: {comment: 'formed'}}
+        )
+      end
+    end
   end
 
   specify 'basic query' do
-    check subject.query(match: { name: "sakurai"})
-  end
-
-  specify 'string query' do
-    check subject.match('sakurai')
-  end
-
-  specify 'array match query' do
-    companies = [found['company'], extra['company']]
-    check subject.match(company: companies)
-  end
-
-  specify 'basic filter' do
-    check subject.query(term: { url_slug: found['url_slug']})
+    check_query subject.query(term: { url_slug: found['url_slug']})
   end
 
   specify 'not query' do
-    check subject.not.query(term: { url_slug: not_found['url_slug']})
+    check_query subject.not.query(term: { url_slug: not_found['url_slug']})
   end
 
   specify 'should query' do
@@ -50,11 +56,11 @@ describe 'Queries' do
   end
 
   specify 'range query' do
-    check subject.query.range(salary: {gte: found['salary']})
+    check_query subject.query.range(salary: {gte: found['salary']})
   end
 
   specify 'more_like' do
-    check subject.more_like(
+    check_query subject.more_like(
       like_text:        found['name'],
       min_doc_freq:     1,
       min_term_freq:    1
@@ -62,7 +68,11 @@ describe 'Queries' do
   end
 
   specify 'fulltext query' do
-    check subject.fulltext(found['name'])
+    check_query subject.fulltext(found['name'])
+  end
+
+  describe 'nested queries' do
+
   end
 
 end

--- a/spec/stretchy/utils_spec.rb
+++ b/spec/stretchy/utils_spec.rb
@@ -3,15 +3,8 @@ require 'spec_helper'
 module Stretchy
   describe Utils do
 
-    context 'consumer class' do
-      class UtilityConsumer
-        include Utils::Methods
-      end
-
-      subject { UtilityConsumer.new }
-
+    shared_examples 'utility methods' do
       describe '#is_empty?' do
-
         specify 'no args' do
           expect(subject.is_empty?).to eq(true)
         end
@@ -59,16 +52,112 @@ module Stretchy
         specify 'true' do
           expect(subject.is_empty?(true)).to eq(false)
         end
-
       end
+
+      describe '#require_params!' do
+        let(:params) { Hash(one: '', three: 'two') }
+        it 'raises error when param is empty' do
+          expect{
+            subject.require_params!(:my_method, params, :one)
+          }.to raise_error(Errors::InvalidParamsError)
+        end
+
+        it 'raises error when param is missing' do
+          expect{
+            subject.require_params!(:my_method, params, :two)
+          }.to raise_error(Errors::InvalidParamsError)
+        end
+
+        it 'does not raise error when param is present' do
+          expect{
+            subject.require_params!(:my_method, params, :three)
+          }.not_to raise_error
+        end
+      end
+
+      describe '#extract_options!' do
+        let(:input) { Hash(one: 1, two: 2, three: 3) }
+        let(:output) { Hash(one: 1) }
+
+        it 'returns existing options' do
+          expect(subject.extract_options!(input, [:one])).to eq(output)
+          expect(input).not_to include(output)
+        end
+      end
+
+      describe '#current_page' do
+        let(:page) { 2 }
+        let(:offset) { 19 }
+        let(:limit) { 10 }
+
+        it 'calculates page from inputs' do
+          expect(subject.current_page(offset, limit)).to eq page
+        end
+      end
+
+      describe '#coerce_id' do
+        it 'coerces int ids' do
+          expect(subject.coerce_id('3')).to eq 3
+        end
+
+        it 'leaves others unaffected' do
+          expect(subject.coerce_id('4three')).to eq '4three'
+        end
+      end
+
+      describe 'nested transformations' do
+        let(:input) { Hash(
+          one: 1,
+          parent: {
+            child: 'leaf',
+            sub: {granchild: 'gc'}
+          }
+        )}
+
+        describe '#dotify' do
+          let(:output) { Hash(
+            'one' => 1,
+            'parent.child' => 'leaf',
+            'parent.sub.granchild' => 'gc'
+          )}
+
+          it 'turns hash into dot notation' do
+            expect(subject.dotify(input)).to eq(output)
+          end
+        end
+
+        describe '#nestify' do
+          let(:output) {Hash(
+            'one' => 1,
+            'parent' => {
+              'parent.child' => 'leaf',
+              'parent.sub' => {
+                'parent.sub.granchild' => 'gc'
+              }
+            }
+          )}
+
+          it 'turns hash into nested dot notation' do
+            expect(subject.nestify(input)).to eq(output)
+          end
+        end
+      end
+    end
+
+    context 'consumer class' do
+      class UtilityConsumer
+        include Utils::Methods
+      end
+
+      subject { UtilityConsumer.new }
+
+      include_examples 'utility methods'
     end
 
     context 'module function' do
       subject { Utils }
 
-      it 'can access the #is_empty? method' do
-        expect(subject.is_empty?([])).to eq(true)
-      end
+      include_examples 'utility methods'
     end
   end
 end


### PR DESCRIPTION
TODOS:

- [ ] Figure out some way to do this:

```ruby
api1 = search.match(phrase: 'hello')
api2 = search.match(name: "susan", child_doc: api1)
# returns
{query: {bool: {must: [
  {match: {name: 'susan'}},
  {nested: {
    path: :child_doc,
    query: {
      'child_doc.phrase' => 'hello'
    }  
  }}
]}}}
```