### PR TITLE
Fix boosts with where and match filters

### DIFF
--- a/lib/stretchy/factory.rb
+++ b/lib/stretchy/factory.rb
@@ -58,14 +58,12 @@ module Stretchy
     end
 
     def context_nodes(params, context = default_context)
-      subparams = dotify_params(params, context)
-
       if context[:boost]
-        params_to_boost(subparams, context)
+        params_to_boost(params, context)
       elsif context[:query]
-        params_to_queries(subparams, context)
+        params_to_queries(dotify_params(params, context), context)
       else
-        params_to_filters(subparams, context)
+        params_to_filters(dotify_params(params, context), context)
       end
     end
 
@@ -121,6 +119,7 @@ module Stretchy
     end
 
     def nested(params, path, context = default_context)
+      pp [:nested, params]
       type, json = if context[:query]
         nodes = params_to_queries(params, context)
         json  = AndCollector.new(nodes, context).json

--- a/spec/integration/boost_spec.rb
+++ b/spec/integration/boost_spec.rb
@@ -13,6 +13,20 @@ describe 'Boosts', :integration do
     check_boost subject.boost.where(url_slug: found['url_slug'])
   end
 
+  specify 'where with weight' do
+    check_boost subject.boost.where(url_slug: found['url_slug'], weight: 100)
+  end
+
+  specify 'match with weight' do
+    check_boost subject.boost.match(name: found['name'], weight: 100)
+  end
+
+  specify 'nested where with weight' do
+    check_boost subject.boost.where(nested: true, games: {
+      comments: {user_id: 3, source: "mobile"}
+    })
+  end
+
   specify 'match' do
     check_boost subject.boost.match(_all: found['name'])
   end


### PR DESCRIPTION
* `.boost.where(nested: true, weight: 5, model: {})`
* same for `.boost.match()`