### PR TITLE
Add Sort support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ From here, you can chain the following query methods:
 * [explain](#explain) - Return score explanations along with documents
 * [fields](#fields) - Only return the specified fields
 * [page](#limit) - Limit, Offset, and Page to define which results to return
+* [sort](#sort) - Sorting fields
 
 ### A note on chaining:
 
@@ -365,6 +366,18 @@ query = query.page(50, per_page: 20)
 ```
 
 Works the same way as ActiveRecord's limit and offset methods - analogous to Elasticsearch's `from` and `size` parameters. The `.page` method allows you to set both at once, and is compatible with the [Kaminari gem](https://github.com/amatsuda/kaminari).
+
+### <a id="sort"></a>Sort
+
+```ruby
+query = query.sort('name')
+# or...
+query = query.sort('name', 'age')
+# or...
+query = query.sort(name: {order: :desc})
+```
+
+Return data sorted by specified field(s). It accepts params used by [ElasticSearch Sort](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html).
 
 ### <a id="explain"></a>Explain
 

--- a/lib/stretchy/api.rb
+++ b/lib/stretchy/api.rb
@@ -105,6 +105,10 @@ module Stretchy
       add_nodes Factory.fulltext_nodes_from_string(params, context)
     end
 
+    def sort(*list)
+      add_body sort: list
+    end
+
     def query(params = {})
       add_params params, :query, :raw_node
     end

--- a/spec/integration/root_spec.rb
+++ b/spec/integration/root_spec.rb
@@ -32,4 +32,20 @@ describe 'Root actions' do
     expect(results.first['_explanation']).to_not be_empty
   end
 
+  it 'sorts ascending by default' do
+    expect(subject.sort('url_slug').to_a[0]['url_slug']).to eq('masahiro-sakurai')
+    expect(subject.sort('url_slug').to_a[1]['url_slug']).to eq('suda-51')
+    expect(subject.sort('url_slug').to_a[2]['url_slug']).to eq('tetsuya-mizuguchi')
+  end
+
+  it 'sorts descending' do
+    expect(subject.sort(url_slug: {order: :desc}).to_a[0]['url_slug']).to eq('tetsuya-mizuguchi')
+    expect(subject.sort(url_slug: {order: :desc}).to_a[1]['url_slug']).to eq('suda-51')
+    expect(subject.sort(url_slug: {order: :desc}).to_a[2]['url_slug']).to eq('masahiro-sakurai')
+  end
+
+  it 'sorts by multiple fields' do
+    expect(subject.sort('_type', 'url_slug').to_a[0]['url_slug']).to eq('masahiro-sakurai')
+    expect(subject.sort('_type', url_slug: {order: :desc}).to_a[2]['url_slug']).to eq('masahiro-sakurai')
+  end
 end


### PR DESCRIPTION
Based on ElastiSearch Sort, it'll add a "sort" attribute into body request.

I would open an Issue to discuss this feature, but the code was quick to write and a PR is better to show it working :)

Let me know if there's something wrong or missing.